### PR TITLE
add hint onto TEE application deployment

### DIFF
--- a/for-developers/confidential-computing/sgx-encrypted-dataset.md
+++ b/for-developers/confidential-computing/sgx-encrypted-dataset.md
@@ -311,6 +311,13 @@ Edit `iexec.json` and fill in the standard keys and the `mrenclave` object:
 }
 ```
 
+{% hint style="info" %}
+Run your TEE image with `SCONE_HASH=1` to get the enclave fingerprint (mrenclave):
+```sh
+docker run -it --rm -e SCONE_HASH=1 nodejs-hello-world:tee-debug
+```
+{% endhint %}
+
 Deploy the app with the standard command:
 ```sh
 iexec app deploy --chain viviani


### PR DESCRIPTION
The following comment was referring to a nonexistent hint:
// fingerprint of the enclave code (mrenclave), see how to retrieve it below