### PR TITLE
Add `sconify.sh` execution to "Use confidential assets" tutorial

### DIFF
--- a/for-developers/confidential-computing/create-your-first-sgx-app.md
+++ b/for-developers/confidential-computing/create-your-first-sgx-app.md
@@ -116,7 +116,7 @@ docker run -it --rm \
 ```
 {% endcode %}
 
-
+Now you can make `sconify.sh` executable and run it:
 ```sh
 # make the script executable
 chmod +x sconify.sh

--- a/for-developers/confidential-computing/sgx-encrypted-dataset.md
+++ b/for-developers/confidential-computing/sgx-encrypted-dataset.md
@@ -273,7 +273,13 @@ docker run -it --rm \
 ```
 {% endcode %}
 
-Run the `sconify.sh` script to build the TEE-debug app.
+As you already did for your first TEE app, make `sconify.sh` executable and run it:
+```sh
+# make the script executable
+chmod +x sconify.sh
+# run the sconify script
+./sconify.sh
+```
 
 ## Test your app on iExec
 


### PR DESCRIPTION
`chmod +x sconify.sh` was missing from the tutorial.