### PR TITLE
Add 'debug SMS' information onto result protection

### DIFF
--- a/for-developers/confidential-computing/end-to-end-encryption.md
+++ b/for-developers/confidential-computing/end-to-end-encryption.md
@@ -37,6 +37,8 @@ This generates two files in `.secrets/beneficiary/`. Make sure to back up the pr
 ...
 ```
 
+Make sure you use the debug Secret Management Service (see [Build trusted applications > Deploy the dataset](create-your-first-sgx-app.md#deploy-the-dataset)).
+
 Now, push the public key to the SMS:
 
 ```bash

--- a/for-developers/confidential-computing/end-to-end-encryption.md
+++ b/for-developers/confidential-computing/end-to-end-encryption.md
@@ -37,7 +37,7 @@ This generates two files in `.secrets/beneficiary/`. Make sure to back up the pr
 ...
 ```
 
-Make sure you use the debug Secret Management Service (see [Build trusted applications > Deploy the dataset](create-your-first-sgx-app.md#deploy-the-dataset)).
+Make sure you use the debug Secret Management Service (see [Build trusted applications > Deploy the dataset](sgx-encrypted-dataset.md#deploy-the-dataset)). Default SMS is production so make sure you use the right one.
 
 Now, push the public key to the SMS:
 


### PR DESCRIPTION
/!\ Please validate the information before merging
As per my tests, it looks like we should use the debug SMS to push our result public encryption key.