### PR TITLE
Initial format lint

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -1,10 +1,10 @@
 redirects:
-    doracle: ./use-cases/iexec-doracle.md
-    intro: ./README.md
-    poco: ./key-concepts/proof-of-contribution.md
-    pocosrc/poco-protocol: ./key-concepts/proof-of-contribution.md
-    release: ./README.md # TODO
-    stackdescription: ./README.md # TODO
-    tee: ./for-developers/confidential-computing/README.md
-    wallet: ./README.md # TODO
-    worker: ./for-workers/quick-worker-start.md
+  doracle: ./use-cases/iexec-doracle.md
+  intro: ./README.md
+  poco: ./key-concepts/proof-of-contribution.md
+  pocosrc/poco-protocol: ./key-concepts/proof-of-contribution.md
+  release: ./README.md # TODO
+  stackdescription: ./README.md # TODO
+  tee: ./for-developers/confidential-computing/README.md
+  wallet: ./README.md # TODO
+  worker: ./for-workers/quick-worker-start.md

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,8 @@
+{
+  "default": true,
+  "line-length": false,
+  "no-duplicate-header": {
+    "allow_different_nesting": true
+  },
+  "no-inline-html": false
+}

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "proseWrap": "never"
+}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 ---
 description: >-
-  iExec is building the future of the Internet infrastructure by decentralizing
-  the cloud computing market. It is the first blockchain-based cloud computing
-  marketplace.
+  iExec is building the future of the Internet infrastructure by decentralizing the cloud computing market. It is the first blockchain-based cloud computing marketplace.
 ---
 
 # iExec Technical Documentation
@@ -17,15 +15,15 @@ Comparable to the oil market, the iExec marketplace offers a uniform and standar
 
 iExec distinguishes between 3 different types of cloud resource providers :
 
-* **Application providers**
+- **Application providers**
 
 Your algorithms can change the world! Developers and application providers can monetize their apps, dapps, functions or algorithms.
 
-* **Computing providers**
+- **Computing providers**
 
 No more CPU cycle wasted! Computing providers can make the most of their servers, by joining the iExec network and renting them.
 
-* **Data providers**
+- **Data providers**
 
 Data is the new gold! Data providers can monetize datasets usage and open up new revenue streams for their assets. A single entity can be all types of providers at the same time.
 
@@ -62,4 +60,3 @@ You may also check out the list of worker pools currently available on the iExec
 Data providers that own valuable datasets can make them available for use by applications through the iExec Data Store.
 
 iExec pay per task model empowers Intel SGX and IBM Datashield to offer new opportunities of creating highly-secure applications that respect data privacy and ownership.
-

--- a/for-developers/advanced/manage-your-apporders.md
+++ b/for-developers/advanced/manage-your-apporders.md
@@ -15,7 +15,7 @@ iexec order init --app
 Edit the apporder part in `iexec.json` to set the conditions to use your app
 
 | key | description |
-| :-- | :-- |
+| --- | --- |
 | app | app address |
 | appprice | price to charge the requester for each execution of the app \(in nRLC\) |
 | volume | number of order created, each usage decrease this number |

--- a/for-developers/advanced/manage-your-apporders.md
+++ b/for-developers/advanced/manage-your-apporders.md
@@ -15,7 +15,7 @@ iexec order init --app
 Edit the apporder part in `iexec.json` to set the conditions to use your app
 
 | key | description |
-| :--- | :--- |
+| :-- | :-- |
 | app | app address |
 | appprice | price to charge the requester for each execution of the app \(in nRLC\) |
 | volume | number of order created, each usage decrease this number |
@@ -53,4 +53,3 @@ An unpublished order is still valid on the blockchain, to invalidate it use the 
 ```text
 iexec order cancel --app <orderHash>
 ```
-

--- a/for-developers/advanced/manage-your-datasetorders.md
+++ b/for-developers/advanced/manage-your-datasetorders.md
@@ -15,7 +15,7 @@ iexec order init --dataset
 Edit the datasetorder part in `iexec.json` to set the conditions to use your dataset
 
 | key | description |
-| :--- | :--- |
+| :-- | :-- |
 | dataset | dataset address |
 | datasetprice | price to charge the requester for each use of the dataset \(in nRLC\) |
 | volume | number of order created, each usage decrease this number |
@@ -53,4 +53,3 @@ An unpublished order is still valid on the blockchain, to invalidate it use the 
 ```text
 iexec order cancel --dataset <orderHash>
 ```
-

--- a/for-developers/advanced/manage-your-datasetorders.md
+++ b/for-developers/advanced/manage-your-datasetorders.md
@@ -15,7 +15,7 @@ iexec order init --dataset
 Edit the datasetorder part in `iexec.json` to set the conditions to use your dataset
 
 | key | description |
-| :-- | :-- |
+| --- | --- |
 | dataset | dataset address |
 | datasetprice | price to charge the requester for each use of the dataset \(in nRLC\) |
 | volume | number of order created, each usage decrease this number |

--- a/for-developers/advanced/task-feedback.md
+++ b/for-developers/advanced/task-feedback.md
@@ -5,15 +5,19 @@
 Sometimes things don't work out right the first time and you may need to debug your application.
 
 - Get debug information of a _task_
+
 ```bash
 iexec task debug <taskid> --chain bellecour
 ```
+
 It allows anyone to know on-chain and off-chain statuses of the _task_.
 
 - Get debug logs of a _task_
+
 ```bash
 iexec task debug <taskid> --logs --chain bellecour
 ```
+
 It allows the requester to retrieve application logs produced by workers.
 
 ## Off-chain statuses
@@ -21,6 +25,7 @@ It allows the requester to retrieve application logs produced by workers.
 One _task_ bought by a requester will result in one off-chain _task_ with one or more _replicates_ depending on the level of trust set by the requester. For a given _task_, each worker involved in the computation will have its own _replicate_ containing the description of the _task_ to compute. The whole computation of a _replicate_ is made of several stages. Each stage completed by a worker will result in an update of its _replicate_ status.
 
 The links between a _task_ to its _replicates_ can be represented as follows:
+
 ```bash
 task1
 ├── replicate1 (workerX)
@@ -29,41 +34,42 @@ task1
 ```
 
 While the _task_ holds a meta status, each _replicate_ has its own status which can be one of these:
+
 | Replicate status | Description |
 | --- | --- |
-| `CREATED` | A new _replicate_ is assigned to a worker just after it asked for more work
-| `RUNNING` | The worker confirms it is going to work on this _replicate_
-| `APP_DOWNLOADING` | The worker is downloading the application
-| `APP_DOWNLOADED` | The download of the application is completed
-| `APP_DOWNLOAD_FAILED` | The download of the application failed
-| `DATA_DOWNLOADING` | The worker is downloading the dataset
-| `DATA_DOWNLOADED` | The download of the dataset is completed
-| `DATA_DOWNLOAD_FAILED` | The download of the dataset failed
-| `COMPUTING` | The worker is computing the _task_
-| `COMPUTED` | The computation is completed
-| `COMPUTE_FAILED` | The computation failed
-| `CAN_CONTRIBUTE` | The worker can contribute the result digest the computation
-| `CANT_CONTRIBUTE_SINCE_STAKE_TOO_LOW` | The worker hasn't enough RLC in its account to contribute (30% of the _task_ in RLC by default)
-| `CANT_CONTRIBUTE_SINCE_TASK_NOT_ACTIVE` | The _task_ is not active on chain. This status usually happens when different workers have contributed on the same _task_ but the consensus has been reached before the related worker contributed.
-| `CANT_CONTRIBUTE_SINCE_AFTER_DEADLINE` | The deadline for the contribution is reached
-| `CANT_CONTRIBUTE_SINCE_CONTRIBUTION_ALREADY_SET` | The worker already contributed for this _task_
-| `CONTRIBUTING` | The worker sent the "contribute(..)" transaction (result digest) on chain
-| `CONTRIBUTE_FAILED` | The contribute transaction failed
-| `CONTRIBUTED` | The worker has contributed on chain
-| `CANT_REVEAL` | The worker cant reveal the proof that it is the owner of the result digest
-| `REVEALING` | The worker sent the "reveal(..)" transaction (proof that he is the owner of the result digest)
-| `REVEALED` | The worker has revealed the proof on chain
-| `REVEAL_FAILED` | The reveal transaction failed
-| `RESULT_UPLOAD_REQUESTED` | The worker has been requested to upload the result to a remote filesystem
-| `RESULT_UPLOAD_REQUEST_FAILED` | The worker did not accept to be requested to upload the result
-| `RESULT_UPLOADING` | The worker is uploading the result
-| `RESULT_UPLOADED` | The result is uploaded to IPFS (over the _iExec Result Proxy_)
-| `RESULT_UPLOAD_FAILED` | The upload of the result failed
-| `COMPLETED` | The whole _task_ is completed meaning the _task_ is finalized. The worker has been rewarded if it is part of the consensus
-| `REVEAL_TIMEOUT` | The worker took too long to reveal its proof (more than 2 periods after the consensus)
-| `WORKER_LOST` | The worker didn't ping the iexec-core scheduler for a while. It is considered as out for this _task_
-| `ABORTED_ON_CONSENSUS_REACHED` | The consensus is reached but the related worker is not part of it
-| `ABORTED_ON_CONTRIBUTION_TIMEOUT` | The worker took too long to contribute (7 periods after the purchase of the _task_)
-| `FAILED` | The worker failed to participate to the _task_
-| `OUT_OF_GAS` | The worker needs some ETH, please refill its wallet
-| `RECOVERING` | The worker has been stopped, it is starting back from where it stopped
+| `CREATED` | A new _replicate_ is assigned to a worker just after it asked for more work |
+| `RUNNING` | The worker confirms it is going to work on this _replicate_ |
+| `APP_DOWNLOADING` | The worker is downloading the application |
+| `APP_DOWNLOADED` | The download of the application is completed |
+| `APP_DOWNLOAD_FAILED` | The download of the application failed |
+| `DATA_DOWNLOADING` | The worker is downloading the dataset |
+| `DATA_DOWNLOADED` | The download of the dataset is completed |
+| `DATA_DOWNLOAD_FAILED` | The download of the dataset failed |
+| `COMPUTING` | The worker is computing the _task_ |
+| `COMPUTED` | The computation is completed |
+| `COMPUTE_FAILED` | The computation failed |
+| `CAN_CONTRIBUTE` | The worker can contribute the result digest the computation |
+| `CANT_CONTRIBUTE_SINCE_STAKE_TOO_LOW` | The worker hasn't enough RLC in its account to contribute (30% of the _task_ in RLC by default) |
+| `CANT_CONTRIBUTE_SINCE_TASK_NOT_ACTIVE` | The _task_ is not active on chain. This status usually happens when different workers have contributed on the same _task_ but the consensus has been reached before the related worker contributed. |
+| `CANT_CONTRIBUTE_SINCE_AFTER_DEADLINE` | The deadline for the contribution is reached |
+| `CANT_CONTRIBUTE_SINCE_CONTRIBUTION_ALREADY_SET` | The worker already contributed for this _task_ |
+| `CONTRIBUTING` | The worker sent the "contribute(..)" transaction (result digest) on chain |
+| `CONTRIBUTE_FAILED` | The contribute transaction failed |
+| `CONTRIBUTED` | The worker has contributed on chain |
+| `CANT_REVEAL` | The worker cant reveal the proof that it is the owner of the result digest |
+| `REVEALING` | The worker sent the "reveal(..)" transaction (proof that he is the owner of the result digest) |
+| `REVEALED` | The worker has revealed the proof on chain |
+| `REVEAL_FAILED` | The reveal transaction failed |
+| `RESULT_UPLOAD_REQUESTED` | The worker has been requested to upload the result to a remote filesystem |
+| `RESULT_UPLOAD_REQUEST_FAILED` | The worker did not accept to be requested to upload the result |
+| `RESULT_UPLOADING` | The worker is uploading the result |
+| `RESULT_UPLOADED` | The result is uploaded to IPFS (over the _iExec Result Proxy_) |
+| `RESULT_UPLOAD_FAILED` | The upload of the result failed |
+| `COMPLETED` | The whole _task_ is completed meaning the _task_ is finalized. The worker has been rewarded if it is part of the consensus |
+| `REVEAL_TIMEOUT` | The worker took too long to reveal its proof (more than 2 periods after the consensus) |
+| `WORKER_LOST` | The worker didn't ping the iexec-core scheduler for a while. It is considered as out for this _task_ |
+| `ABORTED_ON_CONSENSUS_REACHED` | The consensus is reached but the related worker is not part of it |
+| `ABORTED_ON_CONTRIBUTION_TIMEOUT` | The worker took too long to contribute (7 periods after the purchase of the _task_) |
+| `FAILED` | The worker failed to participate to the _task_ |
+| `OUT_OF_GAS` | The worker needs some ETH, please refill its wallet |
+| `RECOVERING` | The worker has been stopped, it is starting back from where it stopped |

--- a/for-developers/confidential-computing/access-confidential-assets.md
+++ b/for-developers/confidential-computing/access-confidential-assets.md
@@ -1,19 +1,23 @@
 # Access confidential assets from your app
 
 {% hint style="warning" %}
+
 Before going any further, make sure you managed to [Build with a TEE framework](choose-your-tee-framework.md).
+
 {% endhint %}
 
-### Secret Management Service (SMS)
+## Secret Management Service (SMS)
 
 You can use confidential assets on iExec thanks to the _iExec Secret Management Service_. This service verifies that the enclave asking for secrets is authorized to do so. Any user - as a confidential asset provider - declares on the blockchain which enclaves are authorized to access it. For each task, the SMS will query the blockchain to determine if the enclave requesting secrets is indeed whitelisted for it.
 
 The SMS currently supports 3 types of secrets:
+
 1. [Application developer secret](app-developer-secret.md): This secret is directly accessible from the application as an environment variable. It is owned by the developer of the application. It can be any kind of data (API key, private key, token, ..) as long as it respects the size limit (max. 4096 kB).
 2. [Requester secrets](requester-secrets.md): These secrets are directly accessible from the application as environment variables, as long as the requester has decided to share them with it. These secrets can be any kind of data as long as they respect the size limit (max. 4096 kB). Before buying a task, a requester secret is pushed into the SMS and is not linked to any application. When a requester buys a task, the requester can declare which secrets can be accessed by the application. Doing so, a single requester secret can be shared with multiple applications.
 3. [Dataset secret](sgx-encrypted-dataset.md): A dataset secret is not directly accessible from the application but its decrypted content is. If a dataset is requested and authorized to be used in it, its content will be automatically decrypted in the application enclave. To monetize such a dataset on iExec, the original dataset must be encrypted using the iExec SDK, its encrypted counterpart must be publicly available and its encryption key pushed into the SMS.
 
 Here is a general overview of how confidential assets are used on iExec:
+
 ```mermaid
 graph TD
     Req[Requester] -->|1.a. Push secret| SMS[SMS]
@@ -29,6 +33,7 @@ graph TD
 ## Next step?
 
 You now understand how these three kinds of confidential assets work on iExec, you can go one step further by learning how to manipulate them:
+
 - [Attach a secret to your app](app-developer-secret.md)
 - [Access requester secrets](requester-secrets.md)
 - [Access a confidential dataset](sgx-encrypted-dataset.md)

--- a/for-developers/confidential-computing/app-developer-secret.md
+++ b/for-developers/confidential-computing/app-developer-secret.md
@@ -10,7 +10,7 @@ Before going any further, make sure you managed to [Build with a TEE framework](
 
 {% hint style="success" %}
 
-**Prerequisites**
+**Prerequisites:**
 
 - [Docker](https://docs.docker.com/install/) 17.05 or higher on the daemon and client.
 - [Nodejs](https://nodejs.org) 14.17.1 or higher.
@@ -179,7 +179,7 @@ In this section, you will:
 
 Create the `Dockerfile`
 
-### For a Javascript application
+**For a Javascript application:**
 
 ```bash
 # Starting from a base image supported by SCONE
@@ -193,7 +193,7 @@ COPY ./src /app
 ENTRYPOINT [ "node", "/app/app.js"]
 ```
 
-### For a Python application
+**For a Python application:**
 
 ```bash
 FROM python:3.7.3-alpine3.10
@@ -232,14 +232,14 @@ In this section, you will create a `Dockerfile` and create your **Gramine TEE ap
 
 You need to copy the `Dockerfile`, then update its `RUN` statements to install required dependencies for your application:
 
-### For a Javascript application
+**For a Javascript application:**
 
 ```bash
 # Install required node dependencies
 RUN npm install axios
 ```
 
-### For a Python application
+**For a Python application:**
 
 ```bash
 # Install required Python dependencies

--- a/for-developers/confidential-computing/choose-your-tee-framework.md
+++ b/for-developers/confidential-computing/choose-your-tee-framework.md
@@ -1,7 +1,9 @@
 # Choose your TEE framework
 
 {% hint style="warning" %}
+
 Before going any further, make sure you managed to [Build your first application](../your-first-app.md).
+
 {% endhint %}
 
 After understanding the fundamentals of Confidential Computing and explaining the technologies behind it, it is time to roll up our sleeves and get hands-on with [enclaves](intel-sgx-technology.md#enclave). In this guide, we will focus on protecting an application - that is already compatible with the iExec platform - using SGX, and without changing the source code. That means we will use the same code we [previously](../your-first-app.md#build-your-app) deployed for a basic iExec application.
@@ -28,11 +30,14 @@ For a deeper understanding, you can have a look to the official [Gramine documen
 ## Let's build
 
 {% hint style="warning" %}
+
 Following steps will show you how to build a Confidential Computing application. The environment you are about to use is a "develop" environment:
+
 - which can be reset at any time
 - where configurations and secrets might be inspected (debug enclaves)
 
 When your developer discovery journey is complete, please reach the [production section](../go-to-production.md).
+
 {% endhint %}
 
 <table data-view="cards">

--- a/for-developers/confidential-computing/create-your-first-gramine-app.md
+++ b/for-developers/confidential-computing/create-your-first-gramine-app.md
@@ -10,7 +10,7 @@ Before going any further, make sure you managed to [Build your first application
 
 {% hint style="success" %}
 
-**Prerequisites**
+**Prerequisites:**
 
 - [Docker](https://docs.docker.com/install/) 17.05 or higher on the daemon and client.
 - [Nodejs](https://nodejs.org) 14.17.1 or higher.
@@ -187,7 +187,7 @@ docker run --rm -e sps=unset <docker-hub-user>/tee-gramine-hello-world:1.0.0
 
 The run is expected to fail but you should look for a `mr_enclave` field in your logs:
 
-```
+```bash
     mr_enclave:  dcec6d7f76520cb996d6e9dac105b9c3d75c7bb4a4d8f3669f6101cbca6aff4f
 ```
 
@@ -226,13 +226,13 @@ You noticed we used `v8-debug.main.pools.iexec.eth` instead of an ethereum addre
 
 If your task does not complete, you can check detailed logs of your task with
 
-```sh
+```bash
 iexec task debug <taskid> --logs --chain bellecour
 ```
 
 If your error is related to Gramine, you might see following output
 
-```
+```bash
 [error] get keys failed, return -[<ERROR_CODE>]
 ```
 

--- a/for-developers/confidential-computing/create-your-first-sgx-app.md
+++ b/for-developers/confidential-computing/create-your-first-sgx-app.md
@@ -10,7 +10,7 @@ Before going any further, make sure you managed to [Build your first application
 
 {% hint style="success" %}
 
-**Prerequisites**
+**Prerequisites:**
 
 - [Docker](https://docs.docker.com/install/) 17.05 or higher on the daemon and client.
 - [Nodejs](https://nodejs.org) 14.17.1 or higher.

--- a/for-developers/confidential-computing/end-to-end-encryption.md
+++ b/for-developers/confidential-computing/end-to-end-encryption.md
@@ -10,7 +10,7 @@ Before going any further, make sure you managed to [Build with a TEE framework](
 
 {% hint style="success" %}
 
-**Prerequisites**
+**Prerequisites:**
 
 - [Docker](https://docs.docker.com/install/) 17.05 or higher on the daemon and client.
 - [Nodejs](https://nodejs.org) 14.17.1 or higher.

--- a/for-developers/confidential-computing/intel-sgx-technology.md
+++ b/for-developers/confidential-computing/intel-sgx-technology.md
@@ -15,6 +15,7 @@ An application's code can be separated into "trusted" and "untrusted" parts wher
 ## Confidential Computing with iExec
 
 Here is a general overview of how a TEE application runs on iExec:
+
 ```mermaid
 graph TD
     Req[Requester] --> |1. Buy task| Chain
@@ -22,10 +23,10 @@ graph TD
     Worker --> |3. Launch TEE application| App[TEE application pre-starting]
     App --> |4. Send report containing integrity <br>information of the enclave| SMS{SMS <br> Is integrity and authenticity <br> of the requesting enclave valid?}
     SMS --> |No| AppFailed[TEE application run aborted]
-    SMS --> |Yes| AppStarted[TEE application started]   
+    SMS --> |Yes| AppStarted[TEE application started]
 
     style AppFailed color:red
-    style AppStarted color:green 
+    style AppStarted color:green
 ```
 
 To build such Confidential Computing (TEE) application, a developer would need to use the Intel® SGX SDK. With iExec, you don't need to manipulate it. Instead iExec supports high-level frameworks, known as TEE frameworks, such as Scone and Gramine. Further sections will cover in details these [TEE frameworks](choose-your-tee-framework.md).

--- a/for-developers/confidential-computing/requester-secrets.md
+++ b/for-developers/confidential-computing/requester-secrets.md
@@ -13,7 +13,7 @@ Before going any further, make sure you managed to [Build with a TEE framework](
 
 {% hint style="success" %}
 
-**Prerequisites**
+**Prerequisites:**
 
 - [Docker](https://docs.docker.com/install/) 17.05 or higher on the daemon and client.
 - [Nodejs](https://nodejs.org) 14.17.1 or higher.
@@ -190,7 +190,7 @@ The Dockerfile and the build scripts are similar to the ones we saw [previously]
 
 Create the `Dockerfile`
 
-### For a Javascript application
+**For a Javascript application:**
 
 ```bash
 # Starting from a base image supported by SCONE
@@ -204,7 +204,7 @@ COPY ./src /app
 ENTRYPOINT [ "node", "/app/app.js"]
 ```
 
-### For a Python application
+**For a Python application:**
 
 ```bash
 FROM python:3.7.3-alpine3.10
@@ -241,14 +241,14 @@ In this section, you will create a `Dockerfile` and create your **Gramine TEE ap
 
 You need to copy the `Dockerfile`, then update its `RUN` statements to install required dependencies for your application:
 
-### For a Javascript application
+**For a Javascript application:**
 
 ```bash
 # Install required node dependencies
 RUN npm install axios
 ```
 
-### For a Python application
+**For a Python application:**
 
 ```bash
 # Install required Python dependencies

--- a/for-developers/confidential-computing/sgx-encrypted-dataset.md
+++ b/for-developers/confidential-computing/sgx-encrypted-dataset.md
@@ -3,15 +3,18 @@
 In this tutorial, you will learn how to leverage an encrypted dataset by using the `IEXEC_DATASET_FILENAME` environment variable in your application.
 
 {% hint style="warning" %}
-The [Gramine TEE framework](choose-your-tee-framework.md#gramine) does not support encrypted datasets at the moment.
-This page is only applicable to the [Scone TEE framework](choose-your-tee-framework.md#scone).
+
+The [Gramine TEE framework](choose-your-tee-framework.md#gramine) does not support encrypted datasets at the moment. This page is only applicable to the [Scone TEE framework](choose-your-tee-framework.md#scone).
+
 {% endhint %}
 
 {% hint style="success" %}
-**Prerequisites**
+
+**Prerequisites:**
 
 - Familiarity with the basic concepts of [Intel® SGX](intel-sgx-technology.md#intel-r-software-guard-extension-intel-r-sgx) and [SCONE](intel-sgx-technology.md#scone-framework) framework.
 - [Build With a Scone TEE application](create-your-first-sgx-app.md)
+
 {% endhint %}
 
 Trusted Execution Environments offer a huge advantage from a security perspective. They guarantee that the behavior of execution does not change even when launched on an untrusted remote machine. The data inside this type of environment is also protected, which allows its monetization while preventing leakage.
@@ -19,11 +22,15 @@ Trusted Execution Environments offer a huge advantage from a security perspectiv
 With iExec, it is possible to authorize only applications you trust to use your datasets and get paid for it. Data is encrypted using standard encryption mechanisms and the plain version never leaves your machine. The encrypted version is made available for usage and the encryption key is pushed into the [SMS](intel-sgx-technology.md#secret-management-service-sms). After you deploy the dataset on iExec it is you, and only you, who decides which application is allowed to get the secret to decrypt it.
 
 {% hint style="warning" %}
+
 Datasets are only decrypted inside authorized [enclaves](intel-sgx-technology.md#enclave) and never leave them. The same thing applies to secrets.
+
 {% endhint %}
 
 {% hint style="info" %}
+
 Your secrets are securely transferred with the SDK from your machine to the SMS over a TLS channel. Internally, your secrets are encrypted with standard AES encryption before being written to disk. Next releases will feature an SMS running entirely inside a trusted enclave.
+
 {% endhint %}
 
 Let's see how to do all of that!
@@ -39,6 +46,7 @@ iexec init --skip-wallet
 ```
 
 Make sure your `chain.json` content is the same as the one described [here](create-your-first-sgx-app.md#update-chain-json).
+
 Init the dataset configuration.
 
 ```bash
@@ -76,7 +84,9 @@ iexec dataset encrypt
 ```
 
 {% hint style="info" %}
+
 `iexec dataset encrypt` will output a checksum, keep this value for a later use.
+
 {% endhint %}
 
 ```bash
@@ -90,7 +100,9 @@ datasets
 As you can see, the command generated the file `datasets/encrypted/my-first-dataset.txt.enc`. That file is the encrypted version of your dataset, you should push it somewhere accessible because the worker will download it during the execution process. You will enter this file's URI in the `iexec.json`file (`multiaddr` attribute) when you will deploy your dataset. Make sure that the URI is a **DIRECT** download link (not a link to a web page for example).
 
 {% hint style="info" %}
+
 You can use Github for example to publish the file but you should add **/raw/** to the URI like this: [https://github.com/&lt;username&gt;/&lt;repo&gt;/raw/master/my-first-dataset.zip](https://github.com/<username>/<repo>/raw/master/my-first-dataset.zip)
+
 {% endhint %}
 
 The file `.secrets/datasets/my-first-dataset.txt.key` is the encryption key, make sure to back it up securely. The file `.secrets/datasets/dataset.key` is just an "alias" in the sense that it is the key of the last encrypted dataset.
@@ -133,6 +145,7 @@ You will get a hexadecimal address for your deployed dataset. Use that address t
 For simplicity, we will use the dataset with a TEE-debug app on a debug workerpool. The debug workerpool is connected to a debug Secret Management Service so we will send the dataset encryption key to this SMS (this is fine for debugging but do not use to store production secrets).
 
 ### Push the dataset secret to the SMS
+
 ```bash
 iexec dataset push-secret --chain bellecour
 ```
@@ -161,7 +174,9 @@ In the folder `src/` create the file `app.js` or `app.py` then copy this code in
 The application reads the content of the dataset and writes it into the result's folder (in an artistic way using **Figlet**):
 
 {% tabs %}
+
 {% tab title="Javascript" %}
+
 {% code title="src/app.js" %}
 
 ```javascript
@@ -203,9 +218,11 @@ const figlet = require("figlet");
 ```
 
 {% endcode %}
+
 {% endtab %}
 
 {% tab title="Python" %}
+
 {% code title="src/app.py" %}
 
 ```python
@@ -241,9 +258,10 @@ with open(iexec_out + '/computed.json', 'w+') as f:
 ```
 
 {% endcode %}
-{% endtab %}
-{% endtabs %}
 
+{% endtab %}
+
+{% endtabs %}
 
 ## Build the TEE docker image
 
@@ -256,6 +274,7 @@ docker build . --tag <docker-hub-user>/hello-world-with-dataset:1.0.0
 ```
 
 Follow the steps described in [Build Scone app > Build the TEE docker image](create-your-first-sgx-app.md#build-the-tee-docker-image).
+
 Create the `sconify.sh` script and update the variables as follow:
 
 ```bash
@@ -299,6 +318,7 @@ iexec app run <appAddress> \
 ## Next step?
 
 Thanks to the explained confidential computing workflow, you now know how to use an encrypted dataset in a Confidential Computing application.
+
 To go further, check out how to:
 
 - [Attach a secret to your app](app-developer-secret.md)

--- a/for-developers/go-to-production.md
+++ b/for-developers/go-to-production.md
@@ -1,9 +1,12 @@
 # Go to production
 
 {% hint style="warning" %}
+
 Before going any further, make sure you managed to:
+
 - [Build your first application](your-first-app.md)
 - [Build Confidential Computing app](confidential-computing/README.md)
+
 {% endhint %}
 
 ## Connect to the production environment
@@ -26,7 +29,9 @@ If you are developing a standard application, then you are already set. To reach
 ## Confidential Computing application
 
 {% hint style="warning" %}
+
 The following applies only to the Scone framework.
+
 {% endhint %}
 
 If you are developing a Confidential Computing application, be aware of following information.
@@ -34,11 +39,14 @@ If you are developing a Confidential Computing application, be aware of followin
 ### Sign your application
 
 Any Confidential Computing application built previously on the [develop environment](confidential-computing/choose-your-tee-framework.md#lets-build) runs in a debug enclave, which, as warned, might be inspected.
+
 To run your application in a production enclave, the application needs to be signed with a key compatible with the Intel® Attestation Service (IAS). Create this key in your [Intel developer Portal](https://api.portal.trustedservices.intel.com/).
 
 When the key is created (`my-signer-key.pem`), update the previous [sconify.sh](confidential-computing/create-your-first-sgx-app.md#build-the-tee-docker-image) script by :
+
 - sharing the folder containing the `my-signer-key.pem`, here `/signer`
 - adding the `--scone-signer` option
+
 ```bash
 docker run -it \
             -v /signer:/signer \
@@ -52,12 +60,14 @@ docker run -it \
 ### Impacts of the SMS in enclave
 
 As you have already learned in previous [confidential assets](confidential-computing/access-confidential-assets.md) section, the iExec SMS is a crucial component for TEE tasks on iExec, being in charge of:
+
 - storing all secrets of iExec users (application developer, requester, dataset owner)
 - defining - by following on-chain governance - which secrets are accessible to a specific enclave.
 
 To reach a higher level of security on the production environment, the iExec SMS runs inside an enclave.
 
 Below is a graph showing how the secrets and session mechanism works:
+
 ```mermaid
 graph TD
     S[Secret owner] -->|1. Push secret| SMS
@@ -96,8 +106,11 @@ graph TD
 ```
 
 As seen in this diagram, required secrets are transferred to an authorized Application enclave over an RA-TLS channel ([Remote Attestation](https://www.intel.com/content/www/us/en/developer/tools/software-guard-extensions/attestation-services.html)).
+
 Inside **Security Services** (yellow area in above diagram), all secrets are protected by an SMS database encryption key, itself backed by the CAS. The SMS enclave needs to prove its authenticity and integrity to the CAS in order to get access to its database encryption key.
+
 To reach a higher level of security, the CAS enclave, which is the only component aware of the SMS database encryption key, is itself [sealed](https://www.intel.com/content/www/us/en/developer/articles/technical/introduction-to-intel-sgx-sealing.html) to a specific platform enclave.
+
 With that pattern, no one, even an administrator or someone with root privileges, can inspect confidential assets of users.
 
 #### CAS update and failure
@@ -111,9 +124,10 @@ In addition, when deploying a new configuration or software release for the SMS,
 #### Backup your secrets
 
 {% hint style="warning" %}
-For these reasons, secrets can be lost at any time, with or without notice. Always keep a local copy of your secrets. Nobody, even iExec, will be able to restore them.
-{% endhint %}
 
+For these reasons, secrets can be lost at any time, with or without notice. Always keep a local copy of your secrets. Nobody, even iExec, will be able to restore them.
+
+{% endhint %}
 
 ## Publish your app to the Dapps store
 

--- a/for-developers/quick-start-for-developers.md
+++ b/for-developers/quick-start-for-developers.md
@@ -131,7 +131,7 @@ iexec app init
 The iExec SDK writes the minimum app configuration in `iexec.json`
 
 | **key** | **description** |
-| :-- | :-- |
+| --- | --- |
 | owner | app owner ethereum address \(default your wallet address\) |
 | name | name of the application |
 | type | type of application \("DOCKER" for docker container\) |

--- a/for-developers/quick-start-for-developers.md
+++ b/for-developers/quick-start-for-developers.md
@@ -7,7 +7,7 @@ description: >-
 
 {% hint style="success" %}
 
-**Prerequisite**
+**Prerequisite:**
 
 - [Nodejs](https://nodejs.org) 14.17.1 or higher
 

--- a/for-workers/manage-a-pool-of-workers.md
+++ b/for-workers/manage-a-pool-of-workers.md
@@ -1,8 +1,6 @@
 ---
 description: >-
-  A workerpool manager is an essential actor in the iExec network. It will be in
-  charge of proposing available computing resources (workers) to task
-  requesters.
+  A workerpool manager is an essential actor in the iExec network. It will be in charge of proposing available computing resources (workers) to task requesters.
 ---
 
 # Manage a workerpool

--- a/for-workers/quick-worker-start.md
+++ b/for-workers/quick-worker-start.md
@@ -1,7 +1,6 @@
 ---
 description: >-
-  A worker is an essential actor of the iExec Network. It will be in charge of
-  computing tasks sent by requesters on the iExec Marketplace.
+  A worker is an essential actor of the iExec Network. It will be in charge of computing tasks sent by requesters on the iExec Marketplace.
 ---
 
 # Quick start
@@ -12,8 +11,8 @@ A worker will be rewarded with RLC for every properly computed tasks.
 
 Please note that:
 
-* your wallet must be loaded with RLC. Some RLC must be deposited to your iExec account in order to stake for incoming tasks.
-* your computer needs at least 2 CPUs.
+- your wallet must be loaded with RLC. Some RLC must be deposited to your iExec account in order to stake for incoming tasks.
+- your computer needs at least 2 CPUs.
 
 ## Start a worker
 
@@ -25,7 +24,7 @@ For security reason, it is **highly recommended** to launch your worker in a vir
 
 After having loaded some RLC and deposited them to your iExec account, you can start your worker.
 
-![](../.gitbook/assets/my-workerpool-dashboard.png)
+![dashboard](../.gitbook/assets/my-workerpool-dashboard.png)
 
 When the worker initialization process is complete, the worker will be started and you will get something like: **You worker is all set**. Your worker will now be able to compute some tasks coming from the iExec network to earn some RLCs.
 

--- a/help/assets.md
+++ b/help/assets.md
@@ -1,11 +1,8 @@
 ---
 description: >-
-  You will probably need to use the iExec logo in your application or website,
-  so we made it available for download in various formats
-
+  You will probably need to use the iExec logo in your application or website, so we made it available for download in various formats
 ---
 
 # Assets
 
-[iExec Assets and logos ](https://iex.ec/assets/)
-
+[iExec Assets and logos](https://iex.ec/assets/)

--- a/help/contact-us.md
+++ b/help/contact-us.md
@@ -2,33 +2,33 @@
 
 ## Contact us
 
-* Email Support: [support@iex.ec](mailto:support@iex.ec)
-* Email General: [contact@iex.ec](mailto:contact@iex.ec)
-* [iExec Help Center](https://iexecproject.atlassian.net/servicedesk/customer/portal/4)
+- Email Support: [support@iex.ec](mailto:support@iex.ec)
+- Email General: [contact@iex.ec](mailto:contact@iex.ec)
+- [iExec Help Center](https://iexecproject.atlassian.net/servicedesk/customer/portal/4)
 
 ### Important Links
 
-* [Website iExec](https://iex.ec/)
-* [Whitepaper](https://iex.ec/wp-content/uploads/pdf/iExec-WPv3.0-English.pdf)
-* [iExec Technical Documentation](../)
-* [SDK](https://github.com/iExecBlockchainComputing/iexec-sdk/blob/master/README.md)
-* [Github iExec](https://github.com/iExecBlockchainComputing)
+- [Website iExec](https://iex.ec/)
+- [Whitepaper](https://iex.ec/wp-content/uploads/pdf/iExec-WPv3.0-English.pdf)
+- [iExec Technical Documentation](../)
+- [SDK](https://github.com/iExecBlockchainComputing/iexec-sdk/blob/master/README.md)
+- [Github iExec](https://github.com/iExecBlockchainComputing)
 
 ### Product Links
 
-* [iExec Dapp Store](https://dapps.iex.ec)
-* [iExec Marketplace](https://market.iex.ec)
-* [iExec Explorer](https://explorer.iex.ec)
-* [iExec Pools registry](https://pools.iex.ec)
-* [iExec Oracle Factory](https://oracle-factory.iex.ec/gallery)
+- [iExec Dapp Store](https://dapps.iex.ec)
+- [iExec Marketplace](https://market.iex.ec)
+- [iExec Explorer](https://explorer.iex.ec)
+- [iExec Pools registry](https://pools.iex.ec)
+- [iExec Oracle Factory](https://oracle-factory.iex.ec/gallery)
 
 ### Social Links
 
-* [Twitter](https://twitter.com/iEx_ec)
-* [Telegram](https://t.me/iexec_discussion)
-* [Reddit](https://www.reddit.com/r/iexec/)
-* [Discord](https://discord.com/invite/pbt9m98wnU)
-* [Facebook](https://www.facebook.com/Iex-ec-1164124083643301/)
-* [Linkedin](https://www.linkedin.com/company/iex.ec/)
-* [Youtube Channel](https://www.youtube.com/channel/UCwWxZWvKVHn3CXnmDooLWtA)
-* [Medium](https://medium.com/iex-ec)
+- [Twitter](https://twitter.com/iEx_ec)
+- [Telegram](https://t.me/iexec_discussion)
+- [Reddit](https://www.reddit.com/r/iexec/)
+- [Discord](https://discord.com/invite/pbt9m98wnU)
+- [Facebook](https://www.facebook.com/Iex-ec-1164124083643301/)
+- [Linkedin](https://www.linkedin.com/company/iex.ec/)
+- [Youtube Channel](https://www.youtube.com/channel/UCwWxZWvKVHn3CXnmDooLWtA)
+- [Medium](https://medium.com/iex-ec)

--- a/help/glossary.md
+++ b/help/glossary.md
@@ -1,24 +1,26 @@
-# A
+# Glossary
 
-## Application
+## A
+
+### Application
 
 A computer program designed to automate processes. An application is generally under the control of different communities such as product managers, project owners, or data center administrators. An application can also be decentralized thanks to the blockchain: see “DApp”.
 
-# B
+## B
 
-## Bellecour Sidechain
+### Bellecour Sidechain
 
 iExec’s product sidechain. It is linked to Ethereum Mainnet with a bridge allowing for the transfer of assets between networks. It allows iExec to be used without paying Ethereum gas fees.
 
 See “Sidechain and xRLC” for more information.
 
-## Beneficiary
+### Beneficiary
 
 An entity indicated by the requester that benefits from the result of a computational execution. It can be the requester, a third party, a smart contract etc.
 
-# C
+## C
 
-## Confidential Computing / Trusted Computing
+### Confidential Computing / Trusted Computing
 
 Ensures computation confidentiality through mechanisms of memory encryption at the hardware level (in a Trusted Execution Environment or TEE). It can be used so that only authorized code can run inside a protected area and manipulate its data. In some cases, ensuring that code runs correctly without any third party altering the execution, is even more important than hiding the computation's data.
 
@@ -26,90 +28,91 @@ This concept is called Trusted Computing. These guarantees are critical for a de
 
 See ”Trusted Execution Environments ('TEE')” for more information
 
-# D
+## D
 
-## Decentralized Application (DApp)
+### Decentralized Application (DApp)
 
 An application built on a decentralized network that combines a smart contract and a frontend user interface. A DApp has its backend code running on a decentralized peer-to-peer network. Contrast this with a traditional application where the backend code is running in fully controlled environments.
 
 See “Application” for more information.
 
-## DApp Provider
+### DApp Provider
 
 Writes, configures, and deploys applications on the iExec platform. Those applications can be DApps or legacy (traditional) applications. Providers can make their applications available for free or ask for a fixed fee for each use of their application.
 
-## Dataset
+### Dataset
 
 A dataset is a collection of related sets of information that is composed of separate elements, such as numbers, semantic-data or variables, that can be manipulated by a computer for practical application. For example, data within the medical industry can be use by healthcare professionals, care providers, insurers, and government agencies.
 
-## Dataset Provider
+### Dataset Provider
 
 Owns datasets that can be monetized in the iExec marketplace.
 
-## Deal
+### Deal
 
 An agreement between all parties (requester and providers) in the iExec network. A deal is created when requester and providers’ orders are matched in the marketplace and recorded in the PoCo smart contract.
 
-# E
+## E
 
-## Ethereum
+### Ethereum
 
 A decentralized, open-source blockchain with smart contract functionality. Ethereum proposes using blockchain technology to maintain a decentralized payment network and to store computer code that can be used to power decentralized applications.
 
-## Enclave
+### Enclave
 
 In confidential computing jargon, an "enclave" is the special memory zone protected by the CPU. For simplicity's sake, we can refer to private regions of memory defined by Intel® SGX application as "enclaves".
 
-## EVM (Ethereum Virtual Machine)
+### EVM (Ethereum Virtual Machine)
 
 The Ethereum's execution environment. This is the virtual machine which executes the smart contracts on the blockchain.
 
-## Explorer (iExec Explorer)
+### Explorer (iExec Explorer)
 
 Tracks and displays all transactions occuring on iExec’s platform. It provides detailed information on the latest deals, tasks, apps, and datasets deployed.
 
-## ERC-20
+### ERC-20
 
 A standard for fungible tokens. This property makes each token exactly the same in type and value as another token.
 
-## ERC-721
+### ERC-721
 
 A standard for non-fungible tokens. This property makes each token unique and capable of having a different value from another token from the same Smart Contract. This uniqueness may come from a variety of sources, including age, rarity, or appearance.
 
-## iExec Academy
+### iExec Academy
 
 iExec’s content aggregator where people can find content related to the project, including articles, demos, documentation, and tutorials.
 
-# I
+## I
 
-## ICO (Initial Coin Offering)
+### ICO (Initial Coin Offering)
 
 A fundraising mechanism where a blockchain-based startup mints its own native crypto asset in exchange for other cryptocurrencies. The goal is to raise funds and, in turn, create a community of incentivized users who want the project to succeed so that the presale tokens gain in value.
 
-# M
+## M
 
-## Mainnet
+### Mainnet
 
 An independent blockchain running its own peer-to-peer network with its own technology and protocol (e.g. Bitcoin and Ethereum). It is a live blockchain where its own cryptocurrencies or tokens have value (when compared against a testnet network).
 
-## Marketplace (iExec)
+### Marketplace (iExec)
 
 The iExec Marketplace connects resource providers with resource users, allowing anyone to monetize or rent computing power, datasets, and applications. The marketplace is a smart contract that acts as escrow anytime you need the network to exchange computing assets.
 
-## Minting
+### Minting
 
 A decentralized method that enables to generate a new token without the involvement of a central authority. It can either be a non-fungible token or a crypto coin.
 
 Please note that minting an NFT (non-fungible token) is a different procedure. To mint an NFT, users usually sign up with a cryptocurrecny wallet on an NFT marketplace (or other platform). Then that create an NFT by uploading a file and paying for the creation. Once the transaction is verified, a new NFT is minted. This process to add NFTs to a blockchain allows creators to sell their photos, videos, and digital 3D objects.
+
 See “ERC-721” for more information.
 
-## MREnclave
+### MREnclave
 
 The MREnclave is a hash value that identifies every enclave. It is obtained from the content of memory pages and access rights. The MREnclave is available after the TEE application is built.
 
-# N
+## N
 
-## nRLC
+### nRLC
 
 N in nRLC stands for nano RLC.
 
@@ -119,126 +122,125 @@ nRLC is the base unit for the PoCo, orders prices in a deal are calculated in nR
 
 See “Deal and PoCo” for more information.
 
-# O
+## O
 
-## Oilers
+### Oilers
 
 A term of affection used to designate the iExec community. Oilers are said to be holding “digital oil”. This term could also be in reference to the iExec whitepaper that states: “ iExec introduces a new paradigm in cloud computing: it will allow the trading of computing resources as commodities; in the same way we may observe with resources such as oil, gold or rice.”
 
-## Oracle
+### Oracle
 
 Data feeds that connect the off-chain world to blockchain products. Oracles act as a link between data that exists in traditional web2 and blockchain smart contracts, and are used to query data in smart contracts.
 
-## Oracle Factory
+### Oracle Factory
 
 The iExec developer interface which allows users to create custom oracles. This interface permits users to create oracles for any type of data, without requiring coding experience, in a few minutes directly from their browser.
 
-# P
+## P
 
-## PoCo (Proof of Contribution)
+### PoCo (Proof of Contribution)
 
 The protocol used by iExec for consensus over off-chain computing.
 
 The iExec platform provides a network where application providers, workers, and users can gather and work together. The fully decentralized nature of iExec implies that no single agent is trusted by default, and that those agents require incentives to contribute correctly. PoCo is a protocol designed to provides trust in an open and decentralized environment of untrusted machines. It also orchestrates the different contributions to the iExec network, ensuring payments are always fair and timely.
 
-# R
+## R
 
-## Requester
+### Requester
 
 A person who buys the execution of a task in the iExec marketplace.
 
-## RLC (Run on lots of computers)
+### RLC (Run on lots of computers)
 
 An Ethereum (ERC20) token launched during the iExec ICO in 2017. This utility token is used on the iExec marketplace to buy and sell computing assets.
 
-
-## Remote attestation
+### Remote attestation
 
 As explained by [Intel](https://software.intel.com/en-us/sgx/attestation-services), the remote attestation is the process that happens before any exchange between a remote provider and an enclave. It allows the provider to verify that the expected software is running in an Intel® SGX-protected way, as well as getting other details about the application being attested. If the attestation is successful, a secure communication channel is established between the provider and the enclave, and secrets can safely land in the latter.
 
-## Roadmap
+### Roadmap
 
 Describes business and technical developments towards the adoption of the iExec protocol. The timeline for this roadmap is organized by quarter for an overview on ongoing projects and the future work. It is available here <https://trello.com/b/oSCT5z09/iexec-adoption-roadmap>
 
-# S
+## S
 
-## Scheduler
+### Scheduler
 
 Organizes the work distribution for workers in a worker pool.
 
-## SDK (Software Development Kit)
+### SDK (Software Development Kit)
 
-A set of tools for interaction with smart contracts and the iExec’s marketplace. It is available as a CLI and JS library. Access SDK here: https://github.com/iExecBlockchainComputing/iexec-sdk
+A set of tools for interaction with smart contracts and the iExec’s marketplace. It is available as a CLI and JS library. Access SDK here: <https://github.com/iExecBlockchainComputing/iexec-sdk>
 
-## SGX (Secure Guard Extension by Intel)
+### SGX (Secure Guard Extension by Intel)
 
 Is a confidential computing technology developed by Intel.
 
 See “Confidential Computing” for more information.
 
-## Sidechain
+### Sidechain
 
 A controlled blockchain deployed over a data center and linked to Ethereum Mainnet with a bridge permitting to transfer assets between the two. iExec’s sidechain “Bellecour” is iExec’s mainnet bridged to ethereum mainnet.
 
-## Smart Contracts
+### Smart Contracts
 
 The fundamental building blocks of Ethereum applications. They are computer programs stored on the blockchain that allows us to convert traditional contracts into digital parallels. Smart contracts are very logical - following an if this then that structure. This means they behave exactly as programmed and cannot be changed.
 
 Nick Szabo used the term "smart contract" in 1994, when he wrote “an introduction to the concept” and, in 1996, “an exploration of what smart contracts could do”.
 
-## SMS (Secret Management Service)
+### SMS (Secret Management Service)
 
 An encrypted database where users' secrets are stored.
 
-## sRLC
+### sRLC
 
 S in sRLC stands for Staked RLC.
 
 The sRLC balance of an account reflects the amount of RLC deposited by the account on the iExec PoCo smart contract. The sRLC balance of an account is managed by the PoCo smart contracts to ensure payments across the platform users. At any time, sRLC can be converted to RLC in the wallet by a withdrawal operation.
 
-## Staking (of RLC)
+### Staking (of RLC)
 
 A mechanism in PoCo that involves a certain amount of Workers’ RLC being ‘locked-up’ during the execution of a task. To prevent malicious workers, the locked RLC is staked as a security deposit. Workers who computed a false result will lose their stake.
 
 See “PoCo” for more information.
 
-# T
+## T
 
-## Task
+### Task
 
 A task within iExec is an instance where computing power is required.
 
-## Testnet
+### Testnet
 
 Used by programmers and developers to test and troubleshoot the aspects and features of a blockchain network to ensure it is ready for mainnet launch.
 
-## Trusted Execution Environment (TEE)
+### Trusted Execution Environment (TEE)
 
 A hardware secure area used to guarantee the confidentiality, integrity, and ownership of code and data.
 
 See” Confidential Computing ” for more information
 
-# W
+## W
 
-## Whitepaper
+### Whitepaper
 
 Explain the purpose and technology behind a project. Producing a whitepaper is a key step for a crypto startup to help investors understand technical information about its concept; whitepapers usually include a roadmap for how the project plans to grow and succeed. iExec’s whitepaper is available [here](https://iex.ec/wp-content/uploads/2022/09/iexec_whitepaper.pdf)
 
-## Workers
+### Workers
 
 Individuals or companies who own computing resources and are willing to make them available for the computation of tasks against payments in RLC. Similarly to blockchain miners, workers want a simple solution that will make their computer part of a large infrastructure that will take care of the details for them.
 
-## Worker Pools
+### Worker Pools
 
 Organize the contributions of Workers. A worker pool is a group of machines, often with similar characteristics, that is led by a Pool Manager.
 
-## Worker Pool Manager
+### Worker Pool Manager
 
 In charge of proposing available computing resources (workers) to task requesters.
 
-# X
+## X
 
-## xRLC
+### xRLC
 
 X in xRLC stands for eXternal.
 

--- a/iexec-products/wallet-management/README.md
+++ b/iexec-products/wallet-management/README.md
@@ -1,7 +1,6 @@
 ---
 description: >-
-  iExec service runs on ethereum blockchain, the deal between agents (data
-  owner, resources provider, requestor, developer) are made using RLC token.
+  iExec service runs on ethereum blockchain, the deal between agents (data owner, resources provider, requestor, developer) are made using RLC token.
 ---
 
 # Wallet Management
@@ -9,4 +8,3 @@ description: >-
 {% page-ref page="wallet-management-using-the-ui.md" %}
 
 {% page-ref page="wallet-management-using-the-sdk.md" %}
-

--- a/iexec-products/wallet-management/wallet-management-using-the-sdk.md
+++ b/iexec-products/wallet-management/wallet-management-using-the-sdk.md
@@ -4,21 +4,23 @@
 
 If you haven’t already, you will need to create an Ethereum wallet:
 
-* Go to MyEtherWallet [https://myetherwallet.com](https://myetherwallet.com)
-* Create a wallet following MEW’s instructions
+- Go to MyEtherWallet [https://myetherwallet.com](https://myetherwallet.com)
+- Create a wallet following MEW’s instructions
 
 {% hint style="warning" %}
+
 Remember your password. You will need it later. \_\*\*\_Back up your wallet properly.
+
 {% endhint %}
 
-![](../../.gitbook/assets/mew_createwallet.png)
+![create-wallet](../../.gitbook/assets/mew_createwallet.png)
 
-* Download your Keystore file, **keep it safe and secret**.
-* To Import the wallet using the Keystore file, you will need to open the downloaded wallet file with any text editor and copy its content.
+- Download your Keystore file, **keep it safe and secret**.
+- To Import the wallet using the Keystore file, you will need to open the downloaded wallet file with any text editor and copy its content.
 
 Useful link:
 
-* How to get an Ethereum wallet ? [https://www.myetherwallet.com/](https://www.myetherwallet.com/)
+- How to get an Ethereum wallet ? [https://www.myetherwallet.com/](https://www.myetherwallet.com/)
 
 ## Credit your wallet with ETH and RLC
 
@@ -28,8 +30,8 @@ Useful links:
 
 For testing purpose and access to limited computing resources:
 
-> * How to get some test ETH \(Kovan\) on your Ethereum wallet ? [https://gitter.im/kovan-testnet/faucet](https://gitter.im/kovan-testnet/faucet)
-> * How to get some test RLC \(Kovan\) on your Ethereum wallet ? [https://faucet.iex.ec/kovan](https://faucet.iex.ec/kovan)
+> - How to get some test ETH \(Kovan\) on your Ethereum wallet ? [https://gitter.im/kovan-testnet/faucet](https://gitter.im/kovan-testnet/faucet)
+> - How to get some test RLC \(Kovan\) on your Ethereum wallet ? [https://faucet.iex.ec/kovan](https://faucet.iex.ec/kovan)
 
 ### Login with Metamask
 
@@ -38,29 +40,31 @@ For testing purpose and access to limited computing resources:
 Once you’ve unlocked your Metamask, you can login on the iExec marketplace [https://market.iex.ec](https://market.iex.ec) with embedded wallet management. In the **Account**, both Balance and Allowance are displayed, and values are expressed in nRLC \(nano RLC\). When a computing deal is closed, a dedicated smart contract is created, an allowance step is mandatory to give authority to this new smart contract to proceed to the payment when the computing task is successfully ended.
 
 {% hint style="info" %}
+
 When your worker joins a worker pool, you must deposit and keep **a minimal of 5 RLC** on your account.  
 This amount is enough to be candidate for any deals.  
 After the job completion, the reward goes into your account.
 
 **The wallet owner must withdraw RLC tokens from his account to his wallet with the SDK or with the marketplace embedded wallet**.
+
 {% endhint %}
 
 ## **Wallet management with the SDK**
 
 The iExec SDK provides all features needed to manage one or multiple wallets.
 
-> * **Wallet creation** : you can directly create a new wallet.
-> * **Keystore directory** : all the wallets you should manage are now stored in a specified location.
-> * **Encrypted wallet** : By default, all the wallet are encrypted in the keystore and protected by a user password.
-> * **Import wallet** : You can import \(recreate a local wallet file\) from a private key.
-> * **Using aliases** : the option --wallet-file allows to use custom filename for your wallet, to ease the management of multiple wallets.
+> - **Wallet creation** : you can directly create a new wallet.
+> - **Keystore directory** : all the wallets you should manage are now stored in a specified location.
+> - **Encrypted wallet** : By default, all the wallet are encrypted in the keystore and protected by a user password.
+> - **Import wallet** : You can import \(recreate a local wallet file\) from a private key.
+> - **Using aliases** : the option --wallet-file allows to use custom filename for your wallet, to ease the management of multiple wallets.
 >
 > ```text
 > cp ~/.ethereum/keystore/UTC--2019-04-23T08-34-59.991000000Z--7E82621Ea3B9BB78d62e32E88cf97f4B855C36D4 my_custom_wallet_filename
 > iexec wallet show --wallet-file my_custom_wallet_filename
 > ```
 >
-> * **Account management** : you can send ETH and RLC to another address. You can deposit and withdraw RLC to your account.
+> - **Account management** : you can send ETH and RLC to another address. You can deposit and withdraw RLC to your account.
 
 Go checkout the [iExec SDK](https://github.com/iExecBlockchainComputing/iexec-sdk/) page to get wallet management option.
 
@@ -83,10 +87,9 @@ The iExecClerk smart contract service is the piece of software that manages unde
 Staking is a important part of the consensus protocol, to prevent attacks and maintain a high level of trust between participants. Workers and schedulers have to commit a security deposit, who computed an erroneous result will lose their stake. The movements of RLC is presented below.
 
 |  | **RLC needed** | **ETH needed** | Staking and incentives |
-| :--- | :--- | :--- | :--- |
+| :-- | :-- | :-- | :-- |
 | Requester | yes | no | payment, token locked during execution |
 | App provider | no | yes for deployment | reward |
 | Dataset provider | no | yes for deployment | reward |
 | Worker | yes | yes | stacking for security deposit, reward |
 | Scheduler | yes | yes | stacking for security deposit, reward |
-

--- a/iexec-products/wallet-management/wallet-management-using-the-sdk.md
+++ b/iexec-products/wallet-management/wallet-management-using-the-sdk.md
@@ -87,7 +87,7 @@ The iExecClerk smart contract service is the piece of software that manages unde
 Staking is a important part of the consensus protocol, to prevent attacks and maintain a high level of trust between participants. Workers and schedulers have to commit a security deposit, who computed an erroneous result will lose their stake. The movements of RLC is presented below.
 
 |  | **RLC needed** | **ETH needed** | Staking and incentives |
-| :-- | :-- | :-- | :-- |
+| --- | --- | --- | --- |
 | Requester | yes | no | payment, token locked during execution |
 | App provider | no | yes for deployment | reward |
 | Dataset provider | no | yes for deployment | reward |

--- a/iexec-products/wallet-management/wallet-management-using-the-ui.md
+++ b/iexec-products/wallet-management/wallet-management-using-the-ui.md
@@ -20,58 +20,62 @@ To help you decide, more details on each of these wallets can be found below.
 
 ### **Portis**
 
-iExec is now also compatible with the[ **Portis** ](https://www.portis.io/)wallet. With Portis wallet, instead of dealing with your own private key, you can log in with just an email address and password.
+iExec is now also compatible with the [**Portis**](https://www.portis.io/) wallet. With Portis wallet, instead of dealing with your own private key, you can log in with just an email address and password.
 
 {% hint style="warning" %}
+
 **You will need enable cookies for use Portis.**
+
 {% endhint %}
 
-![](../../.gitbook/assets/portis-cookies.png)
+![portis-cookies](../../.gitbook/assets/portis-cookies.png)
 
 ## User Interface Guide
 
 To help you understand how to use interface and features of the iExec Wallet Manager, we've integrated an interactive guide that walks you through the user interface.
 
-![](../../.gitbook/assets/1-guide-ui.png)
+![ui-guide](../../.gitbook/assets/1-guide-ui.png)
 
-**Wallet Address**
+**Wallet Address:**
 
 Your wallet address is unique to your own wallet and is your public identity on the blockchain.
 
-![](../../.gitbook/assets/your-address.png)
+![your-address](../../.gitbook/assets/your-address.png)
 
-**Chain selector**
+**Chain selector:**
 
 Using the chain selector, you can select which network you would like to connect to.
 
-![](../../.gitbook/assets/chain-selector.png)
+![chain-selector](../../.gitbook/assets/chain-selector.png)
 
 Remember:
 
-* **Testnet** provides a training environment with **free** test crypto-currencies.
-* Both **Ethereum Mainnet** and **iExec Sidechain** use real cryptocurrencies.
-* **Ethereum Mainnet** network is great for building **decentralized** apps.
-* **iExec Sidechain** is **cheap** and **fast** but is more centralized.
-* The **iExec Sidechain** is linked to **Ethereum Mainnet**. RLC tokens can be transferred between them.
+- **Testnet** provides a training environment with **free** test crypto-currencies.
+- Both **Ethereum Mainnet** and **iExec Sidechain** use real cryptocurrencies.
+- **Ethereum Mainnet** network is great for building **decentralized** apps.
+- **iExec Sidechain** is **cheap** and **fast** but is more centralized.
+- The **iExec Sidechain** is linked to **Ethereum Mainnet**. RLC tokens can be transferred between them.
 
-**Your Wallet**
+**Your Wallet:**
 
 Your crypto-currencies can be found here. When connected to Ethereum Mainnet, all transactions require a small amount of ETH to be used for transaction fees. These transactions fees are sometimes referred to as 'gas' fees. Ensure you have enough ETH in your wallet to pay these.
 
-![](../../.gitbook/assets/wallet.png)
+![wallet](../../.gitbook/assets/wallet.png)
 
-**Your iExec Account**
+**Your iExec Account:**
 
 Your iExec account is linked to your wallet address. The account shows your credit ready to spend on the iExec platform.
 
 {% hint style="warning" %}
+
 Funds must be transferred from your wallet to your iExec account. The iExec account is a smart contract linked to your wallet - iExec can no control over the funds in your account.
+
 {% endhint %}
 
-* When buying resources, you spend the RLC from your iExec Account
-* When selling resources, the RLC earned can be found in your iExec Account
+- When buying resources, you spend the RLC from your iExec Account
+- When selling resources, the RLC earned can be found in your iExec Account
 
-![](../../.gitbook/assets/account.png)
+![account](../../.gitbook/assets/account.png)
 
 ## What you can do with Wallet Manager
 
@@ -79,19 +83,19 @@ Funds must be transferred from your wallet to your iExec account. The iExec acco
 
 Use **Deposit RLC** to top up your iExec Account with funds from your wallet.
 
-![](../../.gitbook/assets/actions.png)
+![deposit](../../.gitbook/assets/actions.png)
 
 ### Withdraw RLC
 
 Use **Withdraw RLC** to withdraw the RLC from your iExec Account to your wallet.
 
-![](../../.gitbook/assets/withdraw-rlc.png)
+![withdraw](../../.gitbook/assets/withdraw-rlc.png)
 
 ### Get ETH \(Access Ethereum Tokens with Moonpay\)
 
 MoonPay is a fiat currency on-ramp solution for accessing blockchain tokens using an everyday bank card. MoonPay can be used to purchase Ethereum tokens directly from within the iExec Wallet Manager.
 
-![](../../.gitbook/assets/moonpay.png)
+![buy-eth](../../.gitbook/assets/moonpay.png)
 
 ### Get RLC \(Using UniSwap\)
 
@@ -99,7 +103,7 @@ You will need RLC tokens to use the iExec platform. One option is to use [UniSwa
 
 Click **Get RLC** to refill your wallet with RLC. Remember that you will need to transfer this into your iExec Account before being able to use it with iExec services.
 
-![](../../.gitbook/assets/get-rlc-uniswap.png)
+![swap](../../.gitbook/assets/get-rlc-uniswap.png)
 
 ## Using the iExec Sidechain
 
@@ -113,7 +117,7 @@ No need to configure anything, your wallet is ready to connect to iExec Sidechai
 
 You will need to manually add the network within Metamask.
 
-![](../../.gitbook/assets/networks.png)
+![add-network](../../.gitbook/assets/networks.png)
 
 **Network Name:** iExec Sidechain
 
@@ -133,11 +137,13 @@ First switch network to **Ethereum Mainnet**.
 
 Click **Send to iExec Sidechain** to transfer some RLC from your wallet to iExec Sidechain.
 
-![](../../.gitbook/assets/send-to-iexec-sidechain.png)
+![bridge](../../.gitbook/assets/send-to-iexec-sidechain.png)
 
 {% hint style="warning" %}
+
 **Remember**:  
 **1 xRLC on iExec Sidechain has the same value than 1 RLC on Ethereum Mainnet.**
+
 {% endhint %}
 
 ### Use iExec on iExec Sidechain
@@ -154,9 +160,10 @@ First switch network to **iExec Sidechain**.
 
 Use **Send to Ethereum Mainnet** to transfer some xRLC from your wallet to Ethereum Mainnet.
 
-![](../../.gitbook/assets/send-to-ethereum-mainnet.png)
+![bridge](../../.gitbook/assets/send-to-ethereum-mainnet.png)
 
 {% hint style="warning" %}
-**Remember**: **1 RLC on Ethereum Mainnet has the same value than 1 xRLC on iExec Sidechain.**
-{% endhint %}
 
+**Remember**: **1 RLC on Ethereum Mainnet has the same value than 1 xRLC on iExec Sidechain.**
+
+{% endhint %}

--- a/key-concepts/pay-per-task-model.md
+++ b/key-concepts/pay-per-task-model.md
@@ -4,13 +4,12 @@ We are introducing a new method for pricing and we have defined several task cat
 
 In the future, we’ll redefine the categories, and provide more advanced tools for helping developers to maximize the usage of the infrastructure
 
-**Categories Description**
+**Categories Description:**
 
 | **Category** | **Maximum Elapsed Time** |
-| :--- | :--- |
-| 0 – XS | 5 min |
-| 1 – S | 20 min |
-| 2 – M | 1 hour |
-| 3 – L | 3 hour |
-| 4 – XL | 10 hour |
-
+| :----------- | :----------------------- |
+| 0 – XS       | 5 min                    |
+| 1 – S        | 20 min                   |
+| 2 – M        | 1 hour                   |
+| 3 – L        | 3 hour                   |
+| 4 – XL       | 10 hour                  |

--- a/key-concepts/pay-per-task-model.md
+++ b/key-concepts/pay-per-task-model.md
@@ -7,7 +7,7 @@ In the future, we’ll redefine the categories, and provide more advanced tools 
 **Categories Description:**
 
 | **Category** | **Maximum Elapsed Time** |
-| :----------- | :----------------------- |
+| ------------ | ------------------------ |
 | 0 – XS       | 5 min                    |
 | 1 – S        | 20 min                   |
 | 2 – M        | 1 hour                   |

--- a/key-concepts/proof-of-contribution.md
+++ b/key-concepts/proof-of-contribution.md
@@ -224,7 +224,7 @@ Based on [\[Sarmenta2002\]](proof-of-contribution.md#requiring-a-trust-level) de
 The trust level is expressed, on-chain, by an integer `trust` such that `threshold = 1 - 1 / trust`.
 
 | **Trust** | **PoCo enforced confidence threshold** |
-| :-------- | :------------------------------------- |
+| --------- | -------------------------------------- |
 | 0         | 0%                                     |
 | 1         | 0%                                     |
 | 2         | 50%                                    |
@@ -239,7 +239,7 @@ This consensus mechanism requires replicable applications. Non-deterministic app
 #### References
 
 | \[Sarmenta2002\] | _\(1, 2\)_ Luis F.G.Sarmenta. Sabotage-tolerance mechanisms for volunteer computing systems. 2002. Future Generation Computer Systems, 18\(4\), 561–572 [Sarmenta2002 PDF](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.67.2962&rep=rep1&type=pdf) |
-| :-- | :-- |
+| --- | --- |
 
 | \[Trust2018\] | _\(1, 2, 3\)_ Trust management in the Proof of Contribution protocol. 2018. Technical report. [Trust2018 PDF](https://github.com/iExecBlockchainComputing/iexec-doc/raw/master/techreport/iExec_PoCo_and_trustmanagement_v1.pdf) |
 
@@ -396,7 +396,7 @@ The tag specifies the need or the availability of features that go beyond the sp
 In V3, tags are 32 bytes \(256 bits\) long array where each bit corresponds to a feature.
 
 | **Value** | **Description** |
-| :-- | :-- |
+| --- | --- |
 | `0x0000000000000000000000000000000000000000000000000000000000000001` | TEE \(physical enclave\) |
 | `0x0000000000000000000000000000000000000000000000000000000000000002` | — |
 | `0x0000000000000000000000000000000000000000000000000000000000000004` | — |
@@ -596,6 +596,6 @@ As described in the protocol parameters section, this reward is `reward = kitty.
 ### References
 
 | \[EIP1154\] | _\(_[_1_](https://docs.iex.ec/poco.html#id8)_,_ [_2_](https://docs.iex.ec/poco.html#id9)_,_ [_3_](https://docs.iex.ec/poco.html#id10)_\)_ [EIP 1154: Oracle Interface](https://eips.ethereum.org/EIPS/eip-1154) |
-| :-- | :-- |
+| --- | --- |
 
 | [\[\*\]](proof-of-contribution.md#other-technical-choices) | value susceptible to change. |

--- a/key-concepts/proof-of-contribution.md
+++ b/key-concepts/proof-of-contribution.md
@@ -1,7 +1,6 @@
 ---
 description: >-
-  PoCo is a protocol designed to provide trust in an open and decentralized
-  environment of untrusted machines.
+  PoCo is a protocol designed to provide trust in an open and decentralized environment of untrusted machines.
 ---
 
 # Proof of Contribution
@@ -20,13 +19,13 @@ In addition to providing trust, PoCo also orchestrates the different contributio
 
 A major quality of PoCo lies in the fact that it is a modular protocol. It comes with features that are context-specific.
 
-### **Result consolidation**
+### Result consolidation
 
 PoCo relies on replication to achieve result consolidation. This is purely a software solution that enforces a confidence level on the result. [This confidence level can be customized by the requester.](proof-of-contribution.md#replication-and-trust)
 
 This layer also supports the onchain consolidation of execution results carried out in Trusted Execution Environments \(TEE\) such as Intel SGX.
 
-### **Secure payment**
+### Secure payment
 
 Once a deal is sealed on the iExec Marketplace, requester funds are locked to ensure all resource providers are paid for their contributions. Resources can take the form of data, applications or computing power.
 
@@ -36,7 +35,7 @@ Worker and scheduler must stake RLC to participate as a computing providers. Bad
 
 This is essential on the public blockchain, but all values can be set to 0 for private blockchain solutions.
 
-### **Permissioning**
+### Permissioning
 
 For an execution to happen, a deal must be signed between the different parties involved. A permission mechanism can be used to control access to applications, datasets and worker pools.
 
@@ -46,107 +45,107 @@ The secure payment layer can be disabled for a private blockchain, or it can als
 
 PoCo describes the succession of contributions that are required to achieve consensus on a given result. Its logic is detailed in two blog articles:
 
-* [PoCo series \#1: Initial PoCo description](https://medium.com/iex-ec/about-trust-and-agents-incentives-4651c138974c)
-* [PoCo series \#3: Updated PoCo description](https://medium.com/iex-ec/poco-series-3-poco-protocole-update-a2c8f8f30126)
+- [PoCo series \#1: Initial PoCo description](https://medium.com/iex-ec/about-trust-and-agents-incentives-4651c138974c)
+- [PoCo series \#3: Updated PoCo description](https://medium.com/iex-ec/poco-series-3-poco-protocole-update-a2c8f8f30126)
 
 The [nominal workflow](https://github.com/iExecBlockchainComputing/iexec-doc/raw/master/techreport/nominalworkflow-ODB.png) is also available in the [technical report section](../help/glossary.md)
 
 Below are the details of the implementations:
 
-1. **Deal**
+**1. Deal:**
 
-  [A deal is sealed by the Clerk. ](proof-of-contribution.md#brokering)This marks the beginning of the execution. An event is created to notify the worker pool’s scheduler.
+[A deal is sealed by the Clerk.](proof-of-contribution.md#brokering) This marks the beginning of the execution. An event is created to notify the worker pool’s scheduler.
 
-  The consensus timer starts when the deal is signed. The corresponding task must be completed before the end of this countdown. Otherwise, the scheduler gets punished by a loss of stake and reputation, and the user reimbursed.
+The consensus timer starts when the deal is signed. The corresponding task must be completed before the end of this countdown. Otherwise, the scheduler gets punished by a loss of stake and reputation, and the user reimbursed.
 
-2. **Initialization**
+**2. Initialization:**
 
-  The scheduler calls the `initialize` method. Given a deal id and a position in the request order \(within the deal window\), this function initializes the corresponding task and returns the _taskid_.`bytes32 taskid = keccak256(abi.encodePacked(_dealid, idx));`
+The scheduler calls the `initialize` method. Given a deal id and a position in the request order \(within the deal window\), this function initializes the corresponding task and returns the _taskid_.`bytes32 taskid = keccak256(abi.encodePacked(_dealid, idx));`
 
-3. **Authorization signature**
+**3. Authorization signature:**
 
-  The scheduler designates workers that participate in this task. The scheduler’s Ethereum wallet signs a message containing the worker’s Ethereum address, the taskid, and \(optionally\) the Ethereum address of the worker's enclave. If the worker doesn't use an enclave, this field must be filled with `address(0)`.
+The scheduler designates workers that participate in this task. The scheduler’s Ethereum wallet signs a message containing the worker’s Ethereum address, the taskid, and \(optionally\) the Ethereum address of the worker's enclave. If the worker doesn't use an enclave, this field must be filled with `address(0)`.
 
-  This Ethereum signature \(authorization\) is sent to the worker through an off-chain channel implemented by the middleware.
+This Ethereum signature \(authorization\) is sent to the worker through an off-chain channel implemented by the middleware.
 
-4. **Task computation**
+**4. Task computation:**
 
-  Once the authorization is received and verified, the worker computes the requested tasks. Results from this execution are placed in the `/iexec_out` folder. The following values are then computed:
+Once the authorization is received and verified, the worker computes the requested tasks. Results from this execution are placed in the `/iexec_out` folder. The following values are then computed:
 
-  * _bytes32 digest_: a digest \(sha256\) of the result folder.
-  * _bytes32 hash_: the hash of the _digest_, used to produce a consensus
-  * _bytes32 seal_: the salted hash of the _digest_, used to prove a worker’s knew the _digest_ value before it is published. `resultHash == keccak256(abi.encodePacked( taskid, resultDigest))` `resultSeal == keccak256(abi.encodePacked(worker, taskid, resultDigest))`
+- _bytes32 digest_: a digest \(sha256\) of the result folder.
+- _bytes32 hash_: the hash of the _digest_, used to produce a consensus
+- _bytes32 seal_: the salted hash of the _digest_, used to prove a worker’s knew the _digest_ value before it is published. `resultHash == keccak256(abi.encodePacked( taskid, resultDigest))` `resultSeal == keccak256(abi.encodePacked(worker, taskid, resultDigest))`
 
-  In computer science, a deterministic algorithm is an algorithm which, given a particular input, will always produce the same output.
+In computer science, a deterministic algorithm is an algorithm which, given a particular input, will always produce the same output.
 
-  Both the `digest`, the `hash` and the `seal` are automatically computed based on the output of the application. If the output is not entirely deterministic, then the application can specify a deterministic file that should be used for building consensus. In order to do so, the application just has to provide the path to the deterministic file using a specific entry `deterministic-output-path` in `${IEXEC_OUT}/computed.json`.
+Both the `digest`, the `hash` and the `seal` are automatically computed based on the output of the application. If the output is not entirely deterministic, then the application can specify a deterministic file that should be used for building consensus. In order to do so, the application just has to provide the path to the deterministic file using a specific entry `deterministic-output-path` in `${IEXEC_OUT}/computed.json`.
 
-  Alternatively, if the application is used in a doracle context (the results are designed to be processed on-chain by receiver smart-contracts), then the value of this callback must be specified in `${IEXEC_OUT}/computed.json` under the entry `callback-data`.
+Alternatively, if the application is used in a doracle context (the results are designed to be processed on-chain by receiver smart-contracts), then the value of this callback must be specified in `${IEXEC_OUT}/computed.json` under the entry `callback-data`.
 
-  If a TEE was used to produce the result, the post-processing enclave will automatically produce an `enclave-signature` entry that contains the enclave signature \(of the resultHash and resultSeal\). TEE certification of results is transparent to the application developer.
+If a TEE was used to produce the result, the post-processing enclave will automatically produce an `enclave-signature` entry that contains the enclave signature \(of the resultHash and resultSeal\). TEE certification of results is transparent to the application developer.
 
-5. **Contribution**
+**5. Contribution:**
 
-  Once the execution has been performed, the worker pushes its contribution using the `contribute` method. The contribution contains:
+Once the execution has been performed, the worker pushes its contribution using the `contribute` method. The contribution contains:
 
-  * _bytes32 taskid_
-  * _bytes32 resultHash_
-  * _bytes32 resultSeal_
-  * _address enclaveChallenge_
+- _bytes32 taskid_
+- _bytes32 resultHash_
+- _bytes32 resultSeal_
+- _address enclaveChallenge_
 
-  The address of the enclave \(specified in the scheduler’s authorization\). If no enclave is specified, this parameter should be set to `address(0)`
+The address of the enclave \(specified in the scheduler’s authorization\). If no enclave is specified, this parameter should be set to `address(0)`
 
-  * _bytes enclaveSign_
+- _bytes enclaveSign_
 
-  The enclave signature. This is required if the `enclaveChallenge` is not `address(0)`. Otherwise, it should be set to the empty byte string `0x`
+The enclave signature. This is required if the `enclaveChallenge` is not `address(0)`. Otherwise, it should be set to the empty byte string `0x`
 
-  * _bytes workerpoolSign_
+- _bytes workerpoolSign_
 
-  The signature computed by the scheduler at step 2.
+The signature computed by the scheduler at step 2.
 
-6. **Consensus**
+**6. Consensus:**
 
-  During the contribution, the consensus is updated and verified. Contributions are possible until the consensus is reached, at which point the contributions are closed. We then enter a 2h reveal phase.
+During the contribution, the consensus is updated and verified. Contributions are possible until the consensus is reached, at which point the contributions are closed. We then enter a 2h reveal phase.
 
-7. **Reveal**
+**7. Reveal:**
 
-  During the reveal phase, workers that have contributed to the consensus must call the `reveal` method with the `resultDigest`. This verifies that the `resultHash` and `resultSeal` they provided are valid. Failure to reveal is equivalent to a bad contribution, and results in a loss of stake and reputation.
+During the reveal phase, workers that have contributed to the consensus must call the `reveal` method with the `resultDigest`. This verifies that the `resultHash` and `resultSeal` they provided are valid. Failure to reveal is equivalent to a bad contribution, and results in a loss of stake and reputation.
 
-8. **Finalize**
+**8. Finalize:**
 
-  Once all contributions have been revealed, or at the end of the reveal period if some \(but not all\) reveals are missing, the scheduler must call the `finalize` method. This finalizes the task, rewards good contribution and punishes bad ones. This must be called before the end of the consensus timer.
+Once all contributions have been revealed, or at the end of the reveal period if some \(but not all\) reveals are missing, the scheduler must call the `finalize` method. This finalizes the task, rewards good contribution and punishes bad ones. This must be called before the end of the consensus timer.
 
 ### Staking and Payment
 
 Among the objectives of PoCo, we want to ensure a worker that contributes correctly is rewarded and, at the same time, that a requester won’t be charged unless a consensus is achieved. This is achieved by locking the requester’s funds for the duration of the consensus, and unlocking them depending on the outcome.
 
-Staking is used to prevent bad behaviour and encourage good contributions.
+Staking is used to prevent bad behavior and encourage good contributions.
 
 Your account, managed by the `Escrow` part of the `IexecClerk`, separates between `balance.stake` \(available, can be withdrawn\) and `balanced.locked` \(unavailable, frozen by a running task\). The `Escrow` exposes the following mechanism:
 
 `lock`: Moves value from the `balance.stake` to `balance.lock`
 
-* Locks the requester stake for payment
-* Locks the scheduler stake to protect against failed consensus
-* Locks the worker stake when making a contribution
+- Locks the requester stake for payment
+- Locks the scheduler stake to protect against failed consensus
+- Locks the worker stake when making a contribution
 
 `unlock`: Moves value from the `balance.lock` back to the `balance.stake`
 
-* Unlock the requester stake when consensus fails
-* Unlock the scheduler stake when consensus is achieved
-* Unlock the worker stake when they contributed to a successful consensus
+- Unlock the requester stake when consensus fails
+- Unlock the scheduler stake when consensus is achieved
+- Unlock the worker stake when they contributed to a successful consensus
 
 `seize`: Confiscate value from `balance.lock`
 
-* Seize the requester stake when the consensus is achieved \(payment\)
-* Seize the scheduler stake when consensus fails \(send to the reward kitty\)
-* Seize the worker stake when a contribution fails \(redistributed to the other workers in the task\)
+- Seize the requester stake when the consensus is achieved \(payment\)
+- Seize the scheduler stake when consensus fails \(send to the reward kitty\)
+- Seize the worker stake when a contribution fails \(redistributed to the other workers in the task\)
 
 `reward`: Award value to the `balance.stake`
 
-* Reward the scheduler when consensus is achieved
-* Reward the worker when they contributed to a successful consensus
-* Reward the app and dataset owner
+- Reward the scheduler when consensus is achieved
+- Reward the worker when they contributed to a successful consensus
+- Reward the app and dataset owner
 
 The requester payment is composed of 3 parts, one for the worker pool, one for the application and one for the dataset. When a consensus is finalized, the payment is seized from the requester and the application and dataset owners are rewarded accordingly. The worker pool part is put inside the `totalReward`. Stake from the losing workers is also added to the `totalReward`. The scheduler takes a fixed portion of the `totalReward` as defined in the worker pool smart contract \(`schedulerRewardRatioPolicy`\).
 
@@ -158,9 +157,9 @@ The remaining reward is then divided between the successful workers proportional
 
 Parameters of the consensus timer. They express the number of reference timers \(category duration\) that are dedicated to each phase. These settings correspond to a 70%-20%-10% distribution between the contribution phase, the reveal phase and the finalize phase.
 
-* `FINAL_DEADLINE_RATIO` This describes the total duration of the consensus. At the end of this timer the consensus must be finalized. If it is not, the user can make a claim to get a refund.
-* `CONTRIBUTION_DEADLINE_RATIO` This describes the duration of the contribution period. The consensus can finalize before that, but no contribution will be allowed after the timer to ensure enough time is left for the reveal and finalize steps.
-* `REVEAL_DEADLINE_RATIO` This describes the duration of the reveal period. Whenever a contribution triggers a consensus, a reveal period of this duration is reserved for the workers to reveal their contribution. Note that this period will necessarily start before the end of the contribution phase.
+- `FINAL_DEADLINE_RATIO` This describes the total duration of the consensus. At the end of this timer the consensus must be finalized. If it is not, the user can make a claim to get a refund.
+- `CONTRIBUTION_DEADLINE_RATIO` This describes the duration of the contribution period. The consensus can finalize before that, but no contribution will be allowed after the timer to ensure enough time is left for the reveal and finalize steps.
+- `REVEAL_DEADLINE_RATIO` This describes the duration of the reveal period. Whenever a contribution triggers a consensus, a reveal period of this duration is reserved for the workers to reveal their contribution. Note that this period will necessarily start before the end of the contribution phase.
 
 Let's consider a task of category GigaPlus, which reference duration is 1 hour. If the task was submitted at 9:27AM, the contributions must be sent before 4:27PM \(16:27\). Whenever a contribution triggers a consensus, a 2 hours long reveal period will start. Whatever happens, the consensus has to be achieved by 7:27PM \(19:27\).
 
@@ -178,9 +177,9 @@ Percentage of the reward kitty for the scheduler per successful execution. If th
 
 Minimum reward on successful execution \(up to the reward kitty value\).
 
-* If the reward kitty contains 42.0 RLC, the reward is 4.2
-* If the reward kitty contains 5.0 RLC, the reward should be 0.5 but gets raised to 1.0
-* If the reward kitty contains 0.7 RLC, the reward should be 0.07 but gets raised to 0.7 \(the whole kitty\)
+- If the reward kitty contains 42.0 RLC, the reward is 4.2
+- If the reward kitty contains 5.0 RLC, the reward should be 0.5 but gets raised to 1.0
+- If the reward kitty contains 0.7 RLC, the reward should be 0.07 but gets raised to 0.7 \(the whole kitty\)
 
 `reward = kitty.percentage(KITTY_RATIO).max(KITTY_MIN).min(kitty)`
 
@@ -188,25 +187,25 @@ Minimum reward on successful execution \(up to the reward kitty value\).
 
 Let's consider a worker pool with the policies `workerStakeRatioPolicy = 35%` and `workerStakeRatioPolicy = 5%`.
 
-* A requester offers `20 RLC` to run a task. The task is free, but it uses a dataset that costs `1 RLC`. The requester locks `21 RLC` and the scheduler `30% * 20 = 6 RLC`. The trust objective is `99%` \(`trust = 100`\)
-* 3 workers contribute:
-  * The first one \(`score = 12 → power = 3`\) contributes `17`. It has to lock `7 RLC` \(35% of the `20 RLC` awarded to the worker pool\).
-  * The second worker \(`score = 100 → power = 32`\) contributes `42`. It also locks `7 RLC`.
-  * The third worker \(`score = 300 → power = 99`\) contributes `42`. It also locks `7 RLC`.
-* After the third contribution, the value `42` has reached a `99.87%` likelihood. Consensus is achieved and the two workers who contributed toward `42` have to reveal.
-* After both workers reveal, the scheduler finalizes the task:
-  * The requester locked value of `21 RLC` is seized.
-  * The dataset owner gets `1 RLC` for the use of its dataset.
-  * Stake from the scheduler is unlocked.
-  * Stakes from workers 2 and 3 are also unlocked.
-  * The first worker stake is seized, and it loses a third of its score. The corresponding `7 RLC` are added to the `totalReward`.
-  * We now have `totalReward = 27 RLC`:
-    * We save 5% for the scheduler, `workersReward = 95% * 27 = 25.65 RLC`
-    * Worker 2 has weight `log2(32) = 5` and worker 3 has a weight `log2(99) = 6`. Total weight is `5+6=11`
-    * Worker 2 takes `25.65 * 5/11 = 11.659090909 RLC`
-    * Worker 3 takes `25.65 * 6/11 = 13.990909090 RLC`
-    * Scheduler takes the remaining `1.350000001 RLC`
-  * If the reward kitty is not empty, the scheduler also takes a part of it.
+- A requester offers `20 RLC` to run a task. The task is free, but it uses a dataset that costs `1 RLC`. The requester locks `21 RLC` and the scheduler `30% * 20 = 6 RLC`. The trust objective is `99%` \(`trust = 100`\)
+- 3 workers contribute:
+  - The first one \(`score = 12 → power = 3`\) contributes `17`. It has to lock `7 RLC` \(35% of the `20 RLC` awarded to the worker pool\).
+  - The second worker \(`score = 100 → power = 32`\) contributes `42`. It also locks `7 RLC`.
+  - The third worker \(`score = 300 → power = 99`\) contributes `42`. It also locks `7 RLC`.
+- After the third contribution, the value `42` has reached a `99.87%` likelihood. Consensus is achieved and the two workers who contributed toward `42` have to reveal.
+- After both workers reveal, the scheduler finalizes the task:
+  - The requester locked value of `21 RLC` is seized.
+  - The dataset owner gets `1 RLC` for the use of its dataset.
+  - Stake from the scheduler is unlocked.
+  - Stakes from workers 2 and 3 are also unlocked.
+  - The first worker stake is seized, and it loses a third of its score. The corresponding `7 RLC` are added to the `totalReward`.
+  - We now have `totalReward = 27 RLC`:
+    - We save 5% for the scheduler, `workersReward = 95% * 27 = 25.65 RLC`
+    - Worker 2 has weight `log2(32) = 5` and worker 3 has a weight `log2(99) = 6`. Total weight is `5+6=11`
+    - Worker 2 takes `25.65 * 5/11 = 11.659090909 RLC`
+    - Worker 3 takes `25.65 * 6/11 = 13.990909090 RLC`
+    - Scheduler takes the remaining `1.350000001 RLC`
+  - If the reward kitty is not empty, the scheduler also takes a part of it.
 
 ## Replication & Trust
 
@@ -225,13 +224,13 @@ Based on [\[Sarmenta2002\]](proof-of-contribution.md#requiring-a-trust-level) de
 The trust level is expressed, on-chain, by an integer `trust` such that `threshold = 1 - 1 / trust`.
 
 | **Trust** | **PoCo enforced confidence threshold** |
-| :--- | :--- |
-| 0 | 0% |
-| 1 | 0% |
-| 2 | 50% |
-| 100 | 99% |
-| 10000 | 99.99% |
-| 1000000 | 99.9999% |
+| :-------- | :------------------------------------- |
+| 0         | 0%                                     |
+| 1         | 0%                                     |
+| 2         | 50%                                    |
+| 100       | 99%                                    |
+| 10000     | 99.99%                                 |
+| 1000000   | 99.9999%                               |
 
 ### Limitation
 
@@ -240,12 +239,9 @@ This consensus mechanism requires replicable applications. Non-deterministic app
 #### References
 
 | \[Sarmenta2002\] | _\(1, 2\)_ Luis F.G.Sarmenta. Sabotage-tolerance mechanisms for volunteer computing systems. 2002. Future Generation Computer Systems, 18\(4\), 561–572 [Sarmenta2002 PDF](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.67.2962&rep=rep1&type=pdf) |
-| :--- | :--- |
-
+| :-- | :-- |
 
 | \[Trust2018\] | _\(1, 2, 3\)_ Trust management in the Proof of Contribution protocol. 2018. Technical report. [Trust2018 PDF](https://github.com/iExecBlockchainComputing/iexec-doc/raw/master/techreport/iExec_PoCo_and_trustmanagement_v1.pdf) |
-| :--- | :--- |
-
 
 ## Brokering
 
@@ -259,13 +255,13 @@ This option relies on the use of cryptographic signatures for order authenticati
 
 An overview of the iExecODB \(Open Decentralized Brokering\) is available in this blog article:
 
-* [PoCo series \#5: Open decentralized brokering on the iExec platform](https://medium.com/iex-ec/poco-series-5-open-decentralized-brokering-on-the-iexec-platform-67b266e330d8)
+- [PoCo series \#5: Open decentralized brokering on the iExec platform](https://medium.com/iex-ec/poco-series-5-open-decentralized-brokering-on-the-iexec-platform-67b266e330d8)
 
 ### Orders structure
 
 As discussed earlier, iExec introduces the offchain signature of orders as a new core element of the iExec Open Decentralized Brokering, the iExec Clerk should match these orders. There are 4 types of orders corresponding to the 4 actors involved: the worker pool, the application, the dataset and the requester. Each order types has to follow a specific structure and is signed using [EIP712](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md) structure signature mechanism.
 
-### Orders description:
+### Orders description
 
 #### **AppOrder**
 
@@ -284,15 +280,15 @@ struct AppOrder
 }
 ```
 
-* `app` Address of the smartcontract describing the application. Must be registered in the AppRegistry.
-* `appprice` Price of a run of the application.
-* `volume` Number of run authorized \(by this order\).
-* `tag` Special requirements for the application \(see [tag](https://docs.iex.ec/poco.html#tag)\)).
-* `datasetrestrict` Matching restrictions. Dataset or group of datasets that can be matched. Let null value to disable.
-* `workerpoolrestrict` Matching restrictions. Workerpool or group of worker pools that can be matched. Let null value to disable.
-* `requesterrestrict` Matching restrictions. Requester or group of requesters that can be matched. Let null value to disable.
-* `salt` A random value to ensure order uniqueness.
-* `sign` cryptographic signature of the order, the smart contract is securely linked to application owner.
+- `app` Address of the smartcontract describing the application. Must be registered in the AppRegistry.
+- `appprice` Price of a run of the application.
+- `volume` Number of run authorized \(by this order\).
+- `tag` Special requirements for the application \(see [tag](https://docs.iex.ec/poco.html#tag)\)).
+- `datasetrestrict` Matching restrictions. Dataset or group of datasets that can be matched. Let null value to disable.
+- `workerpoolrestrict` Matching restrictions. Workerpool or group of worker pools that can be matched. Let null value to disable.
+- `requesterrestrict` Matching restrictions. Requester or group of requesters that can be matched. Let null value to disable.
+- `salt` A random value to ensure order uniqueness.
+- `sign` cryptographic signature of the order, the smart contract is securely linked to application owner.
 
 ### **DatasetOrder**
 
@@ -311,15 +307,15 @@ struct DatasetOrder
 }
 ```
 
-* `dataset` Address of the smartcontract describing the dataset. Must be registered in the DatasetRegistry.
-* `datasetprice` Price of a use of the dataset.
-* `volume` Number of authorized uses \(by this order\).
-* `tag` Special requirements of the dataset \(see [tag](https://docs.iex.ec/poco.html#tag)\)).
-* `apprestrict` Matching restrictions. App or group of apps that can be matched. Let null value to disable.
-* `workerpoolrestrict` Matching restrictions. Workerpool or group of workerpools that can be matched. Let null value to disable.
-* `requesterrestrict` Matching restrictions. Requester or group of requesters that can be matched. Let null value to disable.
-* `salt` A random value to ensure order uniqueness.
-* `sign` cryptographic signature of the order, the smart contract is securely linked to dataset owner.
+- `dataset` Address of the smartcontract describing the dataset. Must be registered in the DatasetRegistry.
+- `datasetprice` Price of a use of the dataset.
+- `volume` Number of authorized uses \(by this order\).
+- `tag` Special requirements of the dataset \(see [tag](https://docs.iex.ec/poco.html#tag)\)).
+- `apprestrict` Matching restrictions. App or group of apps that can be matched. Let null value to disable.
+- `workerpoolrestrict` Matching restrictions. Workerpool or group of workerpools that can be matched. Let null value to disable.
+- `requesterrestrict` Matching restrictions. Requester or group of requesters that can be matched. Let null value to disable.
+- `salt` A random value to ensure order uniqueness.
+- `sign` cryptographic signature of the order, the smart contract is securely linked to dataset owner.
 
 ### **WorkerpoolOrder**
 
@@ -340,17 +336,17 @@ struct WorkerpoolOrder
 }
 ```
 
-* `workerpool` Address of the smartcontract describing the worker pool. Must be registered in the WorkerpoolRegistry.
-* `workerpoolprice` Price of an execution on the worker pool.
-* `volume` Number of executions proposed \(by this order\).
-* `tag` Special features proposed by the workerpool \(see [tag](https://docs.iex.ec/poco.html#tag)\)).
-* `category` Order category.
-* `trust` Trust level used to consolidated results.
-* `apprestrict` Matching restrictions. App or group of apps that can be matched. Let null value to disable.
-* `datasetrestrict` Matching restrictions. Dataset or group of datasets that can be matched. Let null value to disable.
-* `requesterrestrict` Matching restrictions. Requester or group of requesters that can be matched. Let null value to disable.
-* `salt` A random value to ensure order uniqueness.
-* `sign` cryptographic signature of the order, the smart contract is securely linked to worker pool manager.
+- `workerpool` Address of the smartcontract describing the worker pool. Must be registered in the WorkerpoolRegistry.
+- `workerpoolprice` Price of an execution on the worker pool.
+- `volume` Number of executions proposed \(by this order\).
+- `tag` Special features proposed by the workerpool \(see [tag](https://docs.iex.ec/poco.html#tag)\)).
+- `category` Order category.
+- `trust` Trust level used to consolidated results.
+- `apprestrict` Matching restrictions. App or group of apps that can be matched. Let null value to disable.
+- `datasetrestrict` Matching restrictions. Dataset or group of datasets that can be matched. Let null value to disable.
+- `requesterrestrict` Matching restrictions. Requester or group of requesters that can be matched. Let null value to disable.
+- `salt` A random value to ensure order uniqueness.
+- `sign` cryptographic signature of the order, the smart contract is securely linked to worker pool manager.
 
 ### **RequesterOrder**
 
@@ -376,22 +372,22 @@ struct RequestOrder
 }
 ```
 
-* `app` Address of the smartcontract describing the application. Must be registered in the AppRegistry.
-* `appmaxprice` Maximum price allowed by the requester for the payment of the application.
-* `dataset` Address of the smartcontract describing the dataset. Must be registered in the DatasetRegistry. Null if no dataset is required.
-* `datasetmaxprice` Maximum price allowed by the requester for the payment of the dataset \(if any\).
-* `workerpool` Matching restrictions. Worker pool or group of worker pools that are allowed to run tasks from this order. Leave null value to disable check.
-* `workerpoolmaxprice` Maximum price allowed by the requester for the payment of the execution \(scheduler + workers\).
-* `requester` Address of the requester \(paying for the executions\).
-* `volume` Number of tasks that are part of this order \(size of the Bag Of Task\).
-* `tag` Special features required by the requester \(see [tag](https://docs.iex.ec/poco.html#tag)\)).
-* `category` tasks category required.
-* `trust` Minimum trust level required by the requester.
-* `beneficiary` Address of the beneficiary of the computation. Used to require output data encryption.
-* `callback` Address to callback with the results \(following EIP1154 interface\). Let empty \(null\) if no callback is required. Learn more about the callback mechanism.
-* `params` Parameters of the application \(application specific\).
-* `salt` A random value to ensure order uniqueness.
-* `sign` Cryptographic signature of the order, the smart contract is securely linked to requester.
+- `app` Address of the smartcontract describing the application. Must be registered in the AppRegistry.
+- `appmaxprice` Maximum price allowed by the requester for the payment of the application.
+- `dataset` Address of the smartcontract describing the dataset. Must be registered in the DatasetRegistry. Null if no dataset is required.
+- `datasetmaxprice` Maximum price allowed by the requester for the payment of the dataset \(if any\).
+- `workerpool` Matching restrictions. Worker pool or group of worker pools that are allowed to run tasks from this order. Leave null value to disable check.
+- `workerpoolmaxprice` Maximum price allowed by the requester for the payment of the execution \(scheduler + workers\).
+- `requester` Address of the requester \(paying for the executions\).
+- `volume` Number of tasks that are part of this order \(size of the Bag Of Task\).
+- `tag` Special features required by the requester \(see [tag](https://docs.iex.ec/poco.html#tag)\)).
+- `category` tasks category required.
+- `trust` Minimum trust level required by the requester.
+- `beneficiary` Address of the beneficiary of the computation. Used to require output data encryption.
+- `callback` Address to callback with the results \(following EIP1154 interface\). Let empty \(null\) if no callback is required. Learn more about the callback mechanism.
+- `params` Parameters of the application \(application specific\).
+- `salt` A random value to ensure order uniqueness.
+- `sign` Cryptographic signature of the order, the smart contract is securely linked to requester.
 
 ## Tag
 
@@ -400,7 +396,7 @@ The tag specifies the need or the availability of features that go beyond the sp
 In V3, tags are 32 bytes \(256 bits\) long array where each bit corresponds to a feature.
 
 | **Value** | **Description** |
-| :--- | :--- |
+| :-- | :-- |
 | `0x0000000000000000000000000000000000000000000000000000000000000001` | TEE \(physical enclave\) |
 | `0x0000000000000000000000000000000000000000000000000000000000000002` | — |
 | `0x0000000000000000000000000000000000000000000000000000000000000004` | — |
@@ -417,77 +413,106 @@ In order to trigger an execution, a deal must be registered by the iExec Clerk. 
 
 Orders compatibility required:
 
-1. The worker pool’s category and the requester’s category must be equal.
+**1. The worker pool’s category and the requester’s category must be equal.**
 
-  `require(_requestorder.category == _workerpoolorder.category);`
+```sol
+require(_requestorder.category == _workerpoolorder.category);
+```
 
-2. The worker pool’s trust must be greater or equal to the requester’s trust.
+**2. The worker pool’s trust must be greater or equal to the requester’s trust.**
 
-  `require(_requestorder.trust == _workerpoolorder.trust);`
+```sol
+require(_requestorder.trust == _workerpoolorder.trust);
+```
 
-3. The app’s, dataset’s and worker pool’s prices must be less or equal to the requester’s appmaxprice, datasetmaxprice and workerpoolmaxprice.
+**3. The app’s, dataset’s and worker pool’s prices must be less or equal to the requester’s appmaxprice, datasetmaxprice and workerpoolmaxprice.**
 
-  `require(_requestorder.appmaxprice >= _apporder.appprice);`
-  `require(_requestorder.datasetmaxprice >= _datasetorder.datasetprice);`
-  `require(_requestorder.workerpoolmaxprice >= _workerpoolorder.workerpoolprice);`
+```sol
+require(_requestorder.appmaxprice >= _apporder.appprice);
+require(_requestorder.datasetmaxprice >= _datasetorder.datasetprice);
+require(_requestorder.workerpoolmaxprice >= _workerpoolorder.workerpoolprice);
+```
 
-4. The worker pool’s tag must enable all the features required by the app’s tag, the dataset’s tag and the worker pool’s tag.
+**4. The worker pool’s tag must enable all the features required by the app’s tag, the dataset’s tag and the worker pool’s tag.**
 
-  `require(tag & ~_workerpoolorder.tag == 0x0);`
-  `require(tag & ~_workerpoolorder.tag == 0x0);`
+```sol
+require(tag & ~_workerpoolorder.tag == 0x0);
+require(tag & ~_workerpoolorder.tag == 0x0);
+```
 
-5. If TEE tag is required, then application must be TEE compatible.
+**5. If TEE tag is required, then application must be TEE compatible.**
 
-  `require((tag ^ _apporder.tag)[31] & 0x01 == 0x0);`
+```sol
+require((tag ^ _apporder.tag)[31] & 0x01 == 0x0);
+```
 
-6. The app provided by the apporder must match the one required by the requester.
+**6. The app provided by the apporder must match the one required by the requester.**
 
-  `require(_requestorder.app == _apporder.app);`
+```sol
+require(_requestorder.app == _apporder.app);
+```
 
-7. The dataset provided by the datasetorder must match the one required by the requester.
+**7. The dataset provided by the datasetorder must match the one required by the requester.**
 
-  `require(_requestorder.dataset == _datasetorder.dataset);`
+```sol
+require(_requestorder.dataset == _datasetorder.dataset);
+```
 
-8. If the requester specified a worker pool restriction, the worker pool must match this value or be part of the corresponding group.
+**8. If the requester specified a worker pool restriction, the worker pool must match this value or be part of the corresponding group.**
 
-  `require(_checkIdentity(_requestorder.workerpool, _workerpoolorder.workerpool, GROUPMEMBER_PURPOSE));`
+```sol
+require(_checkIdentity(_requestorder.workerpool, _workerpoolorder.workerpool, GROUPMEMBER_PURPOSE));
+```
 
-8. The application must fit the dataset’s and the worker pool’s application restrictions \(if any\).
+**9. The application must fit the dataset’s and the worker pool’s application restrictions \(if any\).**
 
-  `require(_checkIdentity(_datasetorder.apprestrict, _apporder.app, GROUPMEMBER_PURPOSE));`
-  `require(_checkIdentity(_workerpoolorder.apprestrict, _apporder.app, GROUPMEMBER_PURPOSE));`
+```sol
+require(_checkIdentity(_datasetorder.apprestrict, _apporder.app, GROUPMEMBER_PURPOSE));
+require(_checkIdentity(_workerpoolorder.apprestrict, _apporder.app, GROUPMEMBER_PURPOSE));
+```
 
-9. The dataset must fit the application’s and the worker pool’s restrictions \(if any\).
+**10. The dataset must fit the application’s and the worker pool’s restrictions \(if any\).**
 
-  `require(_checkIdentity(_apporder.datasetrestrict, _datasetorder.dataset, GROUPMEMBER_PURPOSE));`
-  `require(_checkIdentity(_workerpoolorder.datasetrestrict, _datasetorder.dataset, GROUPMEMBER_PURPOSE));`
+```sol
+require(_checkIdentity(_apporder.datasetrestrict, _datasetorder.dataset, GROUPMEMBER_PURPOSE));
+require(_checkIdentity(_workerpoolorder.datasetrestrict, _datasetorder.dataset, GROUPMEMBER_PURPOSE));
+```
 
-10. The worker pool must fit the application’s and the dataset’s restrictions \(if any\).
+**11. The worker pool must fit the application’s and the dataset’s restrictions \(if any\).**
 
-  `require(_checkIdentity(_apporder.workerpoolrestrict, _workerpoolorder.workerpool, GROUPMEMBER_PURPOSE));`
-  `require(_checkIdentity(_datasetorder.workerpoolrestrict, _workerpoolorder.workerpool, GROUPMEMBER_PURPOSE));`
+```sol
+require(_checkIdentity(_apporder.workerpoolrestrict, _workerpoolorder.workerpool, GROUPMEMBER_PURPOSE));
+require(_checkIdentity(_datasetorder.workerpoolrestrict, _workerpoolorder.workerpool, GROUPMEMBER_PURPOSE));
+```
 
-11. The requester must fit the application’s, the dataset’s and the worker pool’s restrictions \(if any\).
+**12. The requester must fit the application’s, the dataset’s and the worker pool’s restrictions \(if any\).**
 
-  `require(_checkIdentity(_apporder.requesterrestrict, _requestorder.requester, GROUPMEMBER_PURPOSE));`
-  `require(_checkIdentity(_datasetorder.requesterrestrict, _requestorder.requester, GROUPMEMBER_PURPOSE));`
-  `require(_checkIdentity(_workerpoolorder.requesterrestrict, _requestorder.requester, GROUPMEMBER_PURPOSE));`
+```sol
+require(_checkIdentity(_apporder.requesterrestrict, _requestorder.requester, GROUPMEMBER_PURPOSE));
+require(_checkIdentity(_datasetorder.requesterrestrict, _requestorder.requester, GROUPMEMBER_PURPOSE));
+require(_checkIdentity(_workerpoolorder.requesterrestrict, _requestorder.requester, GROUPMEMBER_PURPOSE));
+```
 
-13. All resources must be registered in the corresponding registries.
+**13. All resources must be registered in the corresponding registries.**
 
-  `require(m_appregistry.isRegistered(_apporder.app));`
-  `require(m_datasetregistry.isRegistered(_datasetorder.dataset));`
-  `require(m_workerpoolregistry.isRegistered(_workerpoolorder.workerpool));`
+```sol
+require(m_appregistry.isRegistered(_apporder.app));
+require(m_datasetregistry.isRegistered(_datasetorder.dataset));
+require(m_workerpoolregistry.isRegistered(_workerpoolorder.workerpool));
+```
 
-14. All orders must be signed or presigned.
+**14. All orders must be signed or presigned.**
 
-  `require(_checkPresignatureOrSignature(App(_apporder.app).m_owner(), _apporder.hash(), _apporder.sign));`
-  `require(_checkPresignatureOrSignature(Dataset(_datasetorder.dataset).m_owner(), _datasetorder.hash(), _datasetorder.sign));`
-  `require(_checkPresignatureOrSignature(Workerpool(_workerpoolorder.workerpool).m_owner(), _workerpoolorder.hash(), _workerpoolorder.sign));`
-  `require(_checkPresignatureOrSignature(_requestorder.requester, _requestorder.hash(), _requestorder.sign));`
+```sol
+require(_checkPresignatureOrSignature(App(_apporder.app).m_owner(), _apporder.hash(), _apporder.sign));
+require(_checkPresignatureOrSignature(Dataset(_datasetorder.dataset).m_owner(), _datasetorder.hash(), _datasetorder.sign));
+require(_checkPresignatureOrSignature(Workerpool(_workerpoolorder.workerpool).m_owner(), _workerpoolorder.hash(), _workerpoolorder.sign));
+require(_checkPresignatureOrSignature(_requestorder.requester, _requestorder.hash(), _requestorder.sign));
+```
 
-15. The deal produced must contain at least one task.
-16. Requester and worker pool must be able to stake.
+**15. The deal produced must contain at least one task.**
+
+**16. Requester and worker pool must be able to stake.**
 
 ### FAQ : How to write an order ?
 
@@ -513,7 +538,7 @@ An application can only perform result encryption inside an enclave. No encrypti
 
 \(TODO: potential issue, key leaking to malicious application with the requester attacking a beneficiary\)
 
-**\[Dataset owner\] How do I limit the usage of my dataset to a specific application**
+**\[Dataset owner\] How do I limit the usage of my dataset to a specific application?**
 
 iExec’s Data wallet and Data store is a complete solution to monetize valuable datasets preserving privacy. Before uploading a dataset you should encrypt it using the iExec SDK. Through this process, the encryption key becomes the valuable data that has to be protected.
 
@@ -531,8 +556,8 @@ Whenever the scheduler proposes to certify a result using the PoCo’s trust lay
 
 A scheduler could therefore emit two kinds of workerpoolorder:
 
-* A workerpoolorder offering execution with the PoCo’s trust layer disabled \(`trust = 0`\) and accepting all applications \(`apprestrict = 0`\)
-* A workerpoolorder offering secure execution of whitelisted tasks. The application whitelist would use the `GroupInterface` to be verified by the iExec Clerk. This group could either be managed by the scheduler or by a certification authority that would check application's determinism.
+- A workerpoolorder offering execution with the PoCo’s trust layer disabled \(`trust = 0`\) and accepting all applications \(`apprestrict = 0`\)
+- A workerpoolorder offering secure execution of whitelisted tasks. The application whitelist would use the `GroupInterface` to be verified by the iExec Clerk. This group could either be managed by the scheduler or by a certification authority that would check application's determinism.
 
 ## Other technical choices
 
@@ -540,11 +565,11 @@ A scheduler could therefore emit two kinds of workerpoolorder:
 
 Some requester might want an onchain callback with the result of the execution. The callback mechanism is based on [\[EIP1154\]](https://docs.iex.ec/pocosrc/poco-else.html#eip1154). The result is a `bytes` value that is set during the `finalize`. The `IexecProxy` implements both side of the [\[EIP1154\]](https://docs.iex.ec/pocosrc/poco-else.html#eip1154).
 
-**Pull**
+**Pull:**
 
 Results are identified by their `taskid` and can be pulled through the `resultFor` method.
 
-**Push**
+**Push:**
 
 In order to use the push approach, the requester can use the `callback` field to specify the address of a smart contract that implements the `receiveResult` method specified in [\[EIP1154\]](https://docs.iex.ec/pocosrc/poco-else.html#eip1154). This method will be called during the finalization with a minimum of 100000 nanoRLC gas to proceed [\[\*\]](https://docs.iex.ec/poco.html#id13).
 
@@ -571,8 +596,6 @@ As described in the protocol parameters section, this reward is `reward = kitty.
 ### References
 
 | \[EIP1154\] | _\(_[_1_](https://docs.iex.ec/poco.html#id8)_,_ [_2_](https://docs.iex.ec/poco.html#id9)_,_ [_3_](https://docs.iex.ec/poco.html#id10)_\)_ [EIP 1154: Oracle Interface](https://eips.ethereum.org/EIPS/eip-1154) |
-| :--- | :--- |
-
+| :-- | :-- |
 
 | [\[\*\]](proof-of-contribution.md#other-technical-choices) | value susceptible to change. |
-| :--- | :--- |

--- a/use-cases/iexec-doracle.md
+++ b/use-cases/iexec-doracle.md
@@ -24,9 +24,9 @@ iExec dOracle builds on top of the decentralized cloud computing platform develo
 
 iExec dOracle allows you to create your own Oracle, with custom logic, while benefiting from the security guarantees of the whole iExec platform.
 
-* It is secure. You can set the desired level of trust for your dOracle execution. The conjunction of random sampling and iExec’s built-in incentive and reputation systems makes your dOracle highly secured.
-* It is easy-to-use. It relies on 2 years of research and development to make the iExec platform simple and developer friendly. Creating your own personalized Decentralized Oracle only takes a simple dockerized application and a few lines of Solidity!
-* It is cheap. It does not rely on bribing or incentivizing honest behavior, only on random sampling and a powerful reputation system to make attack impractical.
+- It is secure. You can set the desired level of trust for your dOracle execution. The conjunction of random sampling and iExec’s built-in incentive and reputation systems makes your dOracle highly secured.
+- It is easy-to-use. It relies on 2 years of research and development to make the iExec platform simple and developer friendly. Creating your own personalized Decentralized Oracle only takes a simple dockerized application and a few lines of Solidity!
+- It is cheap. It does not rely on bribing or incentivize honest behavior, only on random sampling and a powerful reputation system to make attack impractical.
 
 ## How does it work?
 
@@ -34,8 +34,8 @@ iExec dOracle allows you to create your own Oracle, with custom logic, while ben
 
 The iExec architecture is two-sided: the on-chain part is a set of smart contracts that implement the PoCo, handle the incentive and adjudication systems; and the off-chain part is made of workers, that provide computing resources to execute the tasks, and schedulers, that dispatch the tasks to execute between the workers of the worker-pool they manage. Each side of the iExec platform \(worker-pool, computation requester\) create and sign orders that describe the kind of transaction they are willing to enter \(type of hardware, minimum price, etc…\). When several orders of different types are compatible they are matched together on the blockchain, to create a deal. Once a deal is made, the scheduler that is part of the deal will choose a set of workers in his workerpool to execute the task. Each worker will download the dApp \(a docker container\) and run it. Upon execution of the task, each worker sends back two values on the blockchain:
 
-* a hash of the result.
-* after consensus is reached, the corresponding result.
+- a hash of the result.
+- after consensus is reached, the corresponding result.
 
 A normal execution ends when the deal is finalized; all the stakeholders are paid, and the computation requester is free to download the data pointed to by the results field of the `Deal` object on the blockchain.
 
@@ -43,18 +43,18 @@ A normal execution ends when the deal is finalized; all the stakeholders are pai
 
 An iExec dOracle can be seen as an “on-chain API”: fundamentally it is a simple value-store smart contract, with accessors for other smart contracts to get its data, and an internal mechanism to update the data in the most secure way possible. The dOracle architecture is composed of two parts: an on-chain smart contract and a classical iExec dApp \(packaged in a docker container\).
 
-**Off-chain component**
+**Off-chain component:**
 
 The off-chain part of a dOracle is a classical iExec dApp, that will be executed on the iExec platform and be replicated on several workers as part of an iExec computation deal. It contains the oracle logic, for example to query a web API and process the result. Whenever an operator wishes to update the dOracle, it requests a computation like in a normal iExec deal, specifying the dOracle app as dApp, and the parameters if applicable. The dOracle result is written in the `${IEXEC_OUT}/computed.json` file by the dApp, under the `callback_data` key.
 
-```
+```bash
 $ cat ${IEXEC_OUT}/computed.json
 { 'callback-data': '0x48656c6c6f2c20776f726c6421'}
 ```
 
 When the computation ends the worker will send both this `callback-data` \(containing the oracle result\) on the blockchain. The `callback-data` value is stored in the `resultsCallback` field of the `Task` object in the `IexecProxy` smart contract.
 
-**On-chain component**
+**On-chain component:**
 
 The on-chain part is the dOracle contract. Anyone can request an update of its internal state by sending the id of a task corresponding to the execution of the corresponding dApp. With this id, the dOracle contract will query the blockchain and retrieve the deal object. It then checks that the execution passes the dOracle requirements \(trust level, execution tag, that the app is right\). If it does the dOracle contract then decodes the value in the results field and update its fields accordingly. The value is then accessible like a normal value on a smart contract.
 
@@ -68,10 +68,10 @@ The PriceFeed dApp is a simple Node.js script, available at [Kaiko PriceFeed Sou
 
 For example, given the parameters `"BTC USD 9 2019-04-11T13:08:32.605Z"` the price-oracle application will:
 
-* Retrieve the price of BTC in USD at 2019-04-11T13:08:32.605Z
-* Multiply this value by `10e9` \(to capture the price value more accurately as it will be represented by an integer onchain\)
-* Encode the date, the description \(`"btc-usd-9"`\) and the value using `abi.encode`
-* Store this result in `${IEXEC_OUT}/computed.json` under the `callback-data` key
+- Retrieve the price of BTC in USD at 2019-04-11T13:08:32.605Z
+- Multiply this value by `10e9` \(to capture the price value more accurately as it will be represented by an integer onchain\)
+- Encode the date, the description \(`"btc-usd-9"`\) and the value using `abi.encode`
+- Store this result in `${IEXEC_OUT}/computed.json` under the `callback-data` key
 
 iExec will then achieve PoCo consensus on the hash of the `callback-data` value, and will then submit `callback-data` values on-chain, in the `Task` object on the `IexecProxy` smart contract.
 
@@ -124,14 +124,14 @@ internal view returns (bytes memory)
 
 A dOracle smart contract should inherit from the generic `IexecDOracle` contract, and expose two main functionalities:
 
-* An update function, that will call the internal \(and inherited\) `_iexecDoracleGetVerifiedResult` function and process its result to update the dOracle contract internal state.
-* One or several accessor functions, that allows other smart contract to access the oracle value\(s\).
+- An update function, that will call the internal \(and inherited\) `_iexecDoracleGetVerifiedResult` function and process its result to update the dOracle contract internal state.
+- One or several accessor functions, that allows other smart contract to access the oracle value\(s\).
 
 ### The PriceOracle dOracle contract
 
 In the PriceFeed example, the [PriceOracle](https://github.com/iExecBlockchainComputing/iexec-doracle-base/blob/bb4c04dc77c822d16d7ca8baed99f5626e44d7be/contracts/example/PriceOracle.sol) smart contract is made of three parts:
 
-* Its internal state description: a `TimedValue` struct storing the oracle data for a given value, and a `values` field that maps an index of the form `“BTC-USD-9”` to the corresponding `TimedValue` struct value.
+- Its internal state description: a `TimedValue` struct storing the oracle data for a given value, and a `values` field that maps an index of the form `“BTC-USD-9”` to the corresponding `TimedValue` struct value.
 
 ```text
 struct TimedValue
@@ -147,7 +147,7 @@ mapping(bytes32 => TimedValue) public values;
 
 This also allows to read the resulting prices. For example, to get the most recent price of BTC in USD with 9 place precision \(as described above\), query `values(keccak256(bytes("BTC-USD-9")))` from the dOracle contract and this will return a structure containing the value, the associated date, and the details of the request.
 
-* The update function `processResult`, that takes the task id of an execution of the dOracle dApp, calls the internal `_iexecDoracleGetVerifiedResult` and processes the result to update the `values` map.
+- The update function `processResult`, that takes the task id of an execution of the dOracle dApp, calls the internal `_iexecDoracleGetVerifiedResult` and processes the result to update the `values` map.
 
 ```text
 function processResult(bytes32 _oracleCallID)
@@ -173,7 +173,7 @@ public
 
 The PriceFeed dOracle also declares an event `ValueChange`, that is fired whenever an update is made.
 
-* An `updateEnv` function, that can be used by the owner of the dOracle to update its parameters. It simply calls the `_iexecDoracleUpdateSettings` function of its parent `IexecDoracle` contract.
+- An `updateEnv` function, that can be used by the owner of the dOracle to update its parameters. It simply calls the `_iexecDoracleUpdateSettings` function of its parent `IexecDoracle` contract.
 
 ```text
 function updateEnv(
@@ -188,5 +188,3 @@ public onlyOwner
         _iexecDoracleUpdateSettings(_authorizedApp, _authorizedDataset, _authorizedWorkerpool, _requiredtag, _requiredtrust);
 }
 ```
-
-[Next ](https://docs.iex.ec/resources.html)[ Previous](https://docs.iex.ec/consortiumdeployment.html)

--- a/use-cases/iexec-doracle.md
+++ b/use-cases/iexec-doracle.md
@@ -26,7 +26,7 @@ iExec dOracle allows you to create your own Oracle, with custom logic, while ben
 
 - It is secure. You can set the desired level of trust for your dOracle execution. The conjunction of random sampling and iExec’s built-in incentive and reputation systems makes your dOracle highly secured.
 - It is easy-to-use. It relies on 2 years of research and development to make the iExec platform simple and developer friendly. Creating your own personalized Decentralized Oracle only takes a simple dockerized application and a few lines of Solidity!
-- It is cheap. It does not rely on bribing or incentivize honest behavior, only on random sampling and a powerful reputation system to make attack impractical.
+- It is cheap. It does not rely on bribing or incentivizing honest behavior, only on random sampling and a powerful reputation system to make attack impractical.
 
 ## How does it work?
 


### PR DESCRIPTION
## Rational

format the files with `prettier` and lint them with `markdownlint` to keep the whole project style coherent

we will break the work into two steps:

1. define style rules and apply them to the whole repository
2. automate the style rules application

This  PR aimed to define the styles rules and apply them to the whole repository, to keep this PR as small as possible the automation will be added in a [next PR](https://github.com/iExecBlockchainComputing/documentation/pull/142).

## Rules

### prettier

```jsonc
// .prettierrc
{
  // use prettier default recommended rules

  /**
  * disable prose wrap to use the "compact tables" style
  * this also replaces single linebreaks by space as the soft wrapping will display them as space
  * this rule ensures double linebreaks are used to separate prose blocks
  **/
  "proseWrap": "never" 
}
```

### markdownlint

```jsonc
// .markdownlint.json
{
  /** 
  * use markdownlint default recommended rules
  */
  "default": true,
  /**
  * disable max line length (MD013)
  * gitbook renderer takes care of soft wrapping so we don't have to do it manually
  */
  "line-length": false,
  /** 
  * duplicated headers are not recommended as they can breaks generated anchors (MD024)
  * we allow duplicated headers for non-siblings as they are handled by gitbook by adding indexes
  */
  "no-duplicate-header": {
    "allow_different_nesting": true
  },
  /**
  * using `html` in markdown is not considered as good practice (MD033)
  * - using `br` element is the only way to break lines in tables
  * - gitbook rich content (such as cards) heavily relies on html in markdown
  */
  "no-inline-html": false
}

```

## Application

In order to make the whole project compliant with the proposed rules, all the files were formatted and lint.

notables changes:

- single linebreaks have been replaced by double linebreaks when they were meant to separate prose blocks, otherwise, they were replaced by simple space.
- tables use the compact syntax
- all files begin with a level 1 header
- there is only one level 1 header per file
- there are non more headers levels skip
- emphasis text and headers have been reviewed and recategorized when necessary
- unorderred lists use `-`
- images have an alt text