### PR TITLE
Bugfix/debug uris remove retag and fspf

### DIFF
--- a/for-developers/confidential-computing/create-your-first-gramine-app.md
+++ b/for-developers/confidential-computing/create-your-first-gramine-app.md
@@ -213,12 +213,12 @@ iexec storage init --chain bellecour --tee-framework gramine
 You are now ready to run the app
 
 ```bash
-iexec app run --tag tee,gramine --workerpool v8-debug.main.pools.iexec.eth --watch --chain bellecour
+iexec app run --tag tee,gramine --workerpool debug-v8-bellecour.main.pools.iexec.eth --watch --chain bellecour
 ```
 
 {% hint style="info" %}
 
-You noticed we used `v8-debug.main.pools.iexec.eth` instead of an ethereum address, this is an ENS name. The [ENS (Ethereum Name Service)](https://ens.domains/) protocol enables associating decentralized naming to ethereum addresses.
+You noticed we used `debug-v8-bellecour.main.pools.iexec.eth` instead of an ethereum address, this is an ENS name. The [ENS (Ethereum Name Service)](https://ens.domains/) protocol enables associating decentralized naming to ethereum addresses.
 
 {% endhint %}
 

--- a/for-developers/confidential-computing/create-your-first-sgx-app.md
+++ b/for-developers/confidential-computing/create-your-first-sgx-app.md
@@ -19,10 +19,6 @@ Before going any further, make sure you managed to [Build your first application
 
 {% endhint %}
 
-**How would the enclave verify the integrity of the code?**
-
-The short answer is: the application is protected by taking a snapshot of the file system's state. The TEE image will use the [fspf](intel-sgx-technology.md#fspf-file-system-protection-file) feature of SCONE to authenticate the file system directories that would be used by the application \(/bin, /lib...\) as well as the code itself. It takes a snapshot of their state that will be later shared with the worker \(via the Blockchain\) to make sure everything is under control. If we change one bit of one of the authenticated files, the file system's state changes completely and the enclave will refuse to boot since it considers it as a possible attack.
-
 In order to follow this tutorial, you will need to register a [free SCONE Account](https://scontain.com) to access SCONE build tools and curated images from the [SCONE registry](https://gitlab.scontain.com/).
 
 Once your account is activated, you need to [request access to the SCONE build tools for iExec](mailto:info@scontain.com?cc=scone-access@iex.ec&subject=iExec%20Build%20Tools&body=Hi%20SCONE%20Team%2C%0D%0A%0D%0AI%20would%20like%20to%20get%20access%20to%20the%20SCONE%20build%20tools%20for%20iExec:%0A%20-%20scone-production/iexec-sconify-image%0A%20-%20sconecuratedimages%20%28all%20curated%20images%20such%20as%20nodejs%2C%20python...%29%0A%0AMy%20DockerID%20is%20...%0A%0ABest%20regards%0A%0A...).
@@ -60,7 +56,7 @@ Make sure your `chain.json` content is as follows:
   "default": "bellecour",
   "chains": {
     "bellecour": {
-      "sms": { "scone": "https://v8.sms.debug-tee-services.bellecour.iex.ec" }
+      "sms": { "scone": "https://sms.scone-debug.v8-bellecour.iex.ec" }
     }
   }
 }
@@ -100,6 +96,8 @@ ENTRYPOINT="node /app/app.js"
 IMG_NAME=tee-scone-hello-world
 IMG_FROM=<docker-hub-user>/hello-world:1.0.0
 IMG_TO=<docker-hub-user>/${IMG_NAME}:1.0.0-debug
+
+docker pull registry.scontain.com:5050/sconecuratedimages/node:14.4.0-alpine3.11
 
 # Run the sconifier to build the TEE image based on the non-TEE image
 docker run -it --rm \
@@ -189,12 +187,6 @@ Congratulations, you just built your Scone TEE application.
 
 {% hint style="info" %}
 
-The `sconify.sh` script prints the generated docker image name, you must retag this image and push it on dockerhub.
-
-{% endhint %}
-
-{% hint style="info" %}
-
 You may have noticed the `tee-debug` flag in the image name, the built image is actually in TEE debug mode, this allows you to have some debug features while developping the app.
 
 Once you are happy with the debug app, contact us to go to production!
@@ -261,7 +253,7 @@ iexec app deploy --chain bellecour
 
 Specify the tag `--tag tee,scone` in `iexec app run` command to run a tee app.
 
-One last thing, in order to run a **TEE-debug** app you will also need to select a debug workerpool, use the debug workerpool `v8-debug.main.pools.iexec.eth`.
+One last thing, in order to run a **TEE-debug** app you will also need to select a debug workerpool, use the debug workerpool `debug-v8-bellecour.main.pools.iexec.eth`.
 
 The debug workerpool is connected to a debug Secret Management Service (this is fine for debugging but do not use to store production secrets), we will need to init the storage token on this SMS.
 
@@ -273,12 +265,12 @@ iexec storage init --chain bellecour --tee-framework scone
 You are now ready to run the app
 
 ```bash
-iexec app run --tag tee,scone --workerpool v8-debug.main.pools.iexec.eth --watch --chain bellecour
+iexec app run --tag tee,scone --workerpool debug-v8-bellecour.main.pools.iexec.eth --watch --chain bellecour
 ```
 
 {% hint style="info" %}
 
-You noticed we used `v8-debug.main.pools.iexec.eth` instead of an ethereum address, this is an ENS name.
+You noticed we used `debug-v8-bellecour.main.pools.iexec.eth` instead of an ethereum address, this is an ENS name.
 
 The [ENS (Ethereum Name Service)](https://ens.domains/) protocol enables associating decentralized naming to ethereum addresses.
 

--- a/for-developers/confidential-computing/requester-secrets.md
+++ b/for-developers/confidential-computing/requester-secrets.md
@@ -334,7 +334,7 @@ Specify the `--secret` and `--tag tee,scone` options in `iexec app run` command 
 ```bash
 iexec app run <appAddress> \
   --tag tee,scone \
-  --workerpool v8-debug.main.pools.iexec.eth \
+  --workerpool debug-v8-bellecour.main.pools.iexec.eth \
   --secret 1=my-namespace \
   --secret 2=my-key \
   --watch \
@@ -350,7 +350,7 @@ Specify the `--secret` and `--tag tee,gramine` options in `iexec app run` comman
 ```bash
 iexec app run <appAddress> \
   --tag tee,gramine
-  --workerpool v8-debug.main.pools.iexec.eth \
+  --workerpool debug-v8-bellecour.main.pools.iexec.eth \
   --secret 1=my-namespace \
   --secret 2=my-key \
   --watch \

--- a/for-developers/confidential-computing/sgx-encrypted-dataset.md
+++ b/for-developers/confidential-computing/sgx-encrypted-dataset.md
@@ -302,7 +302,7 @@ Deploy the application as described in [Build Scone app](create-your-first-sgx-a
 
 Specify the tag `--tag tee,scone` and the dataset to use `--dataset <datasetAddress>` in `iexec app run` command to run a tee app with a dataset.
 
-One last thing, in order to run a **TEE-debug** app you will also need to select a debug workerpool, use the debug workerpool `v8-debug.main.pools.iexec.eth`.
+One last thing, in order to run a **TEE-debug** app you will also need to select a debug workerpool, use the debug workerpool `debug-v8-bellecour.main.pools.iexec.eth`.
 
 You are now ready to run the app
 
@@ -310,7 +310,7 @@ You are now ready to run the app
 iexec app run <appAddress> \
   --tag tee,scone \
   --dataset <datasetAddress> \
-  --workerpool v8-debug.main.pools.iexec.eth \
+  --workerpool debug-v8-bellecour.main.pools.iexec.eth \
   --watch \
   --chain bellecour
 ```


### PR DESCRIPTION
* On the page  there is a broken link on fspf word, the anchor does not exist in the targeted page

* When we run the sconify script the first time we get an error because the image [registry.scontain.com:5050/sconecuratedimages/node:14.4.0-alpine3.11](http://registry.scontain.com:5050/sconecuratedimages/node:14.4.0-alpine3.11) (I did the hello world nodejs) does not exist. We are asked to make a pull locally but we have to see if we should include a sentence in the documentation to indicate that it is normal.

* In the sconfiy script, the sconify image used is not the right one, you have to switch to [registry.scontain.com:5050/scone-production/iexec-sconify-image:5.7.5-v8](http://registry.scontain.com:5050/scone-production/iexec-sconify-image:5.7.5-v8) (be careful here the v8 is just a coincidence with our version)

* In the section  once we have successfully executed the script, we are asked to push the image on dockerhub and AFTER we have a note that says "you must retag this image and push it on dockerhub". This is not necessarily logical in my opinion, especially since there is no obligation to retag

* The URL of the SMS and the DNS of the debug workerpool are not correct.
  * sms: s[ms.scone-debug.v8-bellecour.iex.ec](http://ms.scone-debug.v8-bellecour.iex.ec/)
  * wp: debug-v8-bellecour.main.pools.iexec.eth